### PR TITLE
Use git commands instead of GH api

### DIFF
--- a/src/git-cmds.ts
+++ b/src/git-cmds.ts
@@ -1,0 +1,51 @@
+// Copyright 2020 Cristian Greco
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as core from '@actions/core';
+
+import * as cmd from './cmd';
+
+export async function gitDiffNameOnly(): Promise<string[]> {
+  const {stdout} = await cmd.execWithOutput('git', ['diff', '--name-only']);
+
+  const files = stdout.split('\n').filter(f => f.length);
+  core.debug(`Git diff files: ${files}`);
+
+  return files;
+}
+
+export async function checkout(branchName: string, startPoint: string) {
+  await cmd.execWithOutput('git', ['checkout', '-b', branchName, startPoint]);
+}
+
+export async function add(paths: string[]) {
+  await cmd.execWithOutput('git', ['add', ...paths]);
+}
+
+export async function commit(message: string) {
+  await cmd.execWithOutput('git', ['commit', '-m', message, '--signoff']);
+}
+
+export async function config(key: string, value: string) {
+  await cmd.execWithOutput('git', ['config', '--local', key, value]);
+}
+
+export async function push(branchName: string) {
+  await cmd.execWithOutput('git', [
+    'push',
+    '--force-with-lease',
+    'origin',
+    `HEAD:refs/heads/${branchName}`
+  ]);
+}

--- a/src/git-commit.ts
+++ b/src/git-commit.ts
@@ -12,26 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as core from '@actions/core';
+import * as git from './git-cmds';
 
-import * as cmd from './cmd';
+export async function commit(
+  files: string[],
+  targetVersion: string,
+  sourceVersion: string
+) {
+  await git.add(files);
 
-export async function gitDiffNameOnly(): Promise<string[]> {
-  const {stdout} = await cmd.execWithOutput('git', ['diff', '--name-only']);
+  const message = `Update Gradle Wrapper from ${sourceVersion} to ${targetVersion}.
 
-  const files = stdout.split('\n').filter(f => f.length);
-  core.debug(`Git diff files: ${files}`);
+Update Gradle Wrapper from ${sourceVersion} to ${targetVersion}.
+- [Release notes](https://docs.gradle.org/${targetVersion}/release-notes.html)`;
 
-  return files;
-}
-
-export async function gitFileMode(path: string): Promise<string> {
-  const {stdout} = await cmd.execWithOutput('git', ['ls-files', '-s', path]);
-
-  const [mode] = stdout.split(' ');
-
-  core.debug(`Path: ${path}`);
-  core.debug(`Mode: ${mode}`);
-
-  return mode;
+  await git.commit(message);
 }

--- a/src/wrapperInfo.ts
+++ b/src/wrapperInfo.ts
@@ -35,11 +35,11 @@ export class WrapperInfo {
     );
 
     core.debug('WrapperInfo');
-    core.debug(`path: ${this.path}`);
-    core.debug(`basePath: ${this.basePath}`);
+    core.debug(`  path: ${this.path}`);
+    core.debug(`  basePath: ${this.basePath}`);
 
     const props = readFileSync(path).toString();
-    core.debug(`props: ${props}`);
+    core.debug(`  props: ${props.replace('\n', ' ')}`);
 
     const distributionUrl = props
       .trim()
@@ -54,8 +54,8 @@ export class WrapperInfo {
 
     if (parsed) {
       const [, version, distType] = parsed;
-      core.debug(`Version: ${version}`);
-      core.debug(`Distribution: ${distType}`);
+      core.debug(`  version: ${version}`);
+      core.debug(`  distribution: ${distType}`);
 
       [this.version, this.distType] = [version, distType];
       return;


### PR DESCRIPTION
Here we switch from using the GH api (blobs, trees) to using raw git
commands executed within the local repo. This helps making fewer api
calls in larger repos (e.g. projects with more than one wrapper), which
avoids hitting api rate limits and makes the action a bit faster.

Additionally we now create a single commit for each wrapper file that is
being updated.