### PR TITLE
Link to Gradle Release Checksums page in the PR message.

### DIFF
--- a/src/github/gh-ops.ts
+++ b/src/github/gh-ops.ts
@@ -18,9 +18,8 @@ import * as core from '@actions/core';
 
 import {GitHubApi, IGitHubApi} from './gh-api';
 import {Inputs} from '../inputs';
-
-const ISSUES_URL =
-  'https://github.com/gradle-update/update-gradle-wrapper-action/issues';
+import {pullRequestText} from '../messages';
+import {Release} from '../releases';
 
 const DEFAULT_LABEL = 'gradle-wrapper';
 
@@ -59,34 +58,22 @@ export class GitHubOps {
 
   async createPullRequest(
     branchName: string,
-    targetVersion: string,
+    distTypes: Set<string>,
+    targetRelease: Release,
     sourceVersion?: string
   ): Promise<string> {
-    const title = sourceVersion
-      ? `Updates Gradle Wrapper from ${sourceVersion} to ${targetVersion}`
-      : `Updates Gradle Wrapper to ${targetVersion}`;
-
-    const body = `${title}.
-
-See release notes: https://docs.gradle.org/${targetVersion}/release-notes.html
-
----
-
-🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.
-
-<details>
-<summary>Need help? 🤔</summary>
-<br />
-
-If something doesn't look right with this PR please file an issue [here](${ISSUES_URL}).
-</details>`;
-
     const targetBranch =
       this.inputs.targetBranch !== ''
         ? this.inputs.targetBranch
         : await this.api.repoDefaultBranch();
 
     core.debug(`Target branch: ${targetBranch}`);
+
+    const {title, body} = pullRequestText(
+      distTypes,
+      targetRelease,
+      sourceVersion
+    );
 
     const pullRequest = await this.api.createPullRequest({
       branchName: `refs/heads/${branchName}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,8 @@ async function run() {
     await git.checkout(branchName, currentCommitSha);
     core.endGroup();
 
+    const distTypes = new Set<string>();
+
     for (const wrapper of wrapperInfos) {
       core.startGroup(`Working with Wrapper at: ${wrapper.path}`);
 
@@ -91,6 +93,8 @@ async function run() {
         core.info(`Wrapper is already up-to-date`);
         continue;
       }
+
+      distTypes.add(wrapper.distType);
 
       const updater = new WrapperUpdater(
         wrapper,
@@ -149,7 +153,8 @@ async function run() {
     core.info('Creating Pull Request');
     const pullRequestUrl = await githubOps.createPullRequest(
       branchName,
-      targetRelease.version,
+      distTypes,
+      targetRelease,
       commitDataList.length === 1 ? commitDataList[0].sourceVersion : undefined
     );
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,64 @@
+// Copyright 2020-2021 Cristian Greco
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Release} from './releases';
+
+const ISSUES_URL =
+  'https://github.com/gradle-update/update-gradle-wrapper-action/issues';
+
+export function pullRequestText(
+  distTypes: Set<string>,
+  targetRelease: Release,
+  sourceVersion?: string
+): {title: string; body: string} {
+  const targetVersion = targetRelease.version;
+
+  const title = sourceVersion
+    ? `Updates Gradle Wrapper from ${sourceVersion} to ${targetVersion}`
+    : `Updates Gradle Wrapper to ${targetVersion}`;
+
+  const bodyHeader = `${title}.
+
+Read the release notes: https://docs.gradle.org/${targetVersion}/release-notes.html`;
+
+  let bodyChecksum = `The checksums of the Wrapper JAR and the distribution binary have been successfully verified.
+
+- Gradle release: \`${targetVersion}\`
+`;
+
+  if (distTypes.has('bin')) {
+    bodyChecksum += `- Distribution (-bin) zip checksum: \`${targetRelease.binChecksum}\`\n`;
+  }
+
+  if (distTypes.has('all')) {
+    bodyChecksum += `- Distribution (-all) zip checksum: \`${targetRelease.allChecksum}\`\n`;
+  }
+
+  bodyChecksum += `- Wrapper JAR Checksum: \`${targetRelease.wrapperChecksum}\`
+
+You can find the reference checksum values at https://gradle.org/release-checksums/`;
+
+  const bodyFooter = `🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.
+
+<details>
+<summary>Need help? 🤔</summary>
+<br />
+
+If something doesn't look right with this PR please file an issue [here](${ISSUES_URL}).
+</details>`;
+
+  const body = `${bodyHeader}\n\n---\n\n${bodyChecksum}\n\n---\n\n${bodyFooter}`;
+
+  return {title, body};
+}

--- a/tests/github/gh-ops.test.ts
+++ b/tests/github/gh-ops.test.ts
@@ -19,6 +19,7 @@ import nock from 'nock';
 import {GitHubOps} from '../../src/github/gh-ops';
 import {IGitHubApi} from '../../src/github/gh-api';
 import {Inputs} from '../../src/inputs/';
+import {Release} from '../../src/releases';
 
 nock.disableNetConnect();
 
@@ -62,6 +63,19 @@ beforeEach(() => {
 });
 
 describe('createPullRequest', () => {
+  const branchName = 'a-branch-name';
+
+  const distributionTypes = new Set(['bin']);
+
+  const targetRelease: Release = {
+    version: '1.0.1',
+    allChecksum: 'distAllChecksum',
+    binChecksum: 'distBinChecksum',
+    wrapperChecksum: 'wrapperChecksum'
+  };
+
+  const sourceVersion = '1.0.0';
+
   describe('Pull Request creation', () => {
     beforeEach(() => {
       mockGitHubApi.repoDefaultBranch = jest.fn().mockResolvedValue('master');
@@ -78,9 +92,10 @@ describe('createPullRequest', () => {
 
     it('creates a Pull Request and returns its url', async () => {
       const pullRequestUrl = await githubOps.createPullRequest(
-        'a-branch-name',
-        '1.0.1',
-        '1.0.0'
+        branchName,
+        distributionTypes,
+        targetRelease,
+        sourceVersion
       );
 
       expect(mockGitHubApi.repoDefaultBranch).toHaveBeenCalled();
@@ -113,9 +128,10 @@ describe('createPullRequest', () => {
       mockInputs.targetBranch = 'release-v2';
 
       const pullRequestUrl = await githubOps.createPullRequest(
-        'a-branch-name',
-        '1.0.1',
-        '1.0.0'
+        branchName,
+        distributionTypes,
+        targetRelease,
+        sourceVersion
       );
 
       expect(mockGitHubApi.repoDefaultBranch).not.toHaveBeenCalled();
@@ -148,9 +164,10 @@ describe('createPullRequest', () => {
       mockInputs.reviewers = ['username', 'collaborator'];
 
       const pullRequestUrl = await githubOps.createPullRequest(
-        'a-branch-name',
-        '1.0.1',
-        '1.0.0'
+        branchName,
+        distributionTypes,
+        targetRelease,
+        sourceVersion
       );
 
       expect(mockGitHubApi.repoDefaultBranch).toHaveBeenCalled();
@@ -186,9 +203,10 @@ describe('createPullRequest', () => {
       mockInputs.labels = ['custom-label', 'help wanted'];
 
       const pullRequestUrl = await githubOps.createPullRequest(
-        'a-branch-name',
-        '1.0.1',
-        '1.0.0'
+        branchName,
+        distributionTypes,
+        targetRelease,
+        sourceVersion
       );
 
       expect(mockGitHubApi.repoDefaultBranch).toHaveBeenCalled();
@@ -227,7 +245,12 @@ describe('createPullRequest', () => {
       });
 
       await expect(
-        githubOps.createPullRequest('a-branch-name', '1.0.1', '1.0.0')
+        githubOps.createPullRequest(
+          branchName,
+          distributionTypes,
+          targetRelease,
+          sourceVersion
+        )
       ).rejects.toThrowError('fetch repo error');
     });
 
@@ -239,7 +262,12 @@ describe('createPullRequest', () => {
       });
 
       await expect(
-        githubOps.createPullRequest('a-branch-name', '1.0.1', '1.0.0')
+        githubOps.createPullRequest(
+          branchName,
+          distributionTypes,
+          targetRelease,
+          sourceVersion
+        )
       ).rejects.toThrowError('create pull request error');
     });
   });

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -1,0 +1,177 @@
+// Copyright 2020-2021 Cristian Greco
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {pullRequestText} from '../src/messages';
+import {Release} from '../src/releases';
+
+describe('pullRequestText', () => {
+  const distributionTypes = new Set(['all', 'bin']);
+
+  const targetRelease: Release = {
+    version: '1.0.1',
+    allChecksum: 'dist-all-checksum-value',
+    binChecksum: 'dist-bin-checksum-value',
+    wrapperChecksum: 'wrapper-jar-checksum-value'
+  };
+
+  const sourceVersion = '1.0.0';
+
+  it('returns title and body text of Pull Request', () => {
+    const {title, body} = pullRequestText(
+      distributionTypes,
+      targetRelease,
+      sourceVersion
+    );
+
+    expect(title).toEqual('Updates Gradle Wrapper from 1.0.0 to 1.0.1');
+
+    expect(body).toEqual(`Updates Gradle Wrapper from 1.0.0 to 1.0.1.
+
+Read the release notes: https://docs.gradle.org/1.0.1/release-notes.html
+
+---
+
+The checksums of the Wrapper JAR and the distribution binary have been successfully verified.
+
+- Gradle release: \`1.0.1\`
+- Distribution (-bin) zip checksum: \`dist-bin-checksum-value\`
+- Distribution (-all) zip checksum: \`dist-all-checksum-value\`
+- Wrapper JAR Checksum: \`wrapper-jar-checksum-value\`
+
+You can find the reference checksum values at https://gradle.org/release-checksums/
+
+---
+
+🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.
+
+<details>
+<summary>Need help? 🤔</summary>
+<br />
+
+If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
+</details>`);
+  });
+
+  describe('when source version is unspecified', () => {
+    it('returns title and body text with only the target version', () => {
+      const {title, body} = pullRequestText(distributionTypes, targetRelease);
+
+      expect(title).toEqual('Updates Gradle Wrapper to 1.0.1');
+
+      expect(body).toEqual(`Updates Gradle Wrapper to 1.0.1.
+
+Read the release notes: https://docs.gradle.org/1.0.1/release-notes.html
+
+---
+
+The checksums of the Wrapper JAR and the distribution binary have been successfully verified.
+
+- Gradle release: \`1.0.1\`
+- Distribution (-bin) zip checksum: \`dist-bin-checksum-value\`
+- Distribution (-all) zip checksum: \`dist-all-checksum-value\`
+- Wrapper JAR Checksum: \`wrapper-jar-checksum-value\`
+
+You can find the reference checksum values at https://gradle.org/release-checksums/
+
+---
+
+🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.
+
+<details>
+<summary>Need help? 🤔</summary>
+<br />
+
+If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
+</details>`);
+    });
+  });
+
+  describe('when distribution type is "bin"', () => {
+    const binDistributionType = new Set(['bin']);
+
+    it('the body text contains only the "bin" checksum value', () => {
+      const {title, body} = pullRequestText(
+        binDistributionType,
+        targetRelease,
+        sourceVersion
+      );
+
+      expect(title).toEqual('Updates Gradle Wrapper from 1.0.0 to 1.0.1');
+
+      expect(body).toEqual(`Updates Gradle Wrapper from 1.0.0 to 1.0.1.
+
+Read the release notes: https://docs.gradle.org/1.0.1/release-notes.html
+
+---
+
+The checksums of the Wrapper JAR and the distribution binary have been successfully verified.
+
+- Gradle release: \`1.0.1\`
+- Distribution (-bin) zip checksum: \`dist-bin-checksum-value\`
+- Wrapper JAR Checksum: \`wrapper-jar-checksum-value\`
+
+You can find the reference checksum values at https://gradle.org/release-checksums/
+
+---
+
+🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.
+
+<details>
+<summary>Need help? 🤔</summary>
+<br />
+
+If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
+</details>`);
+    });
+  });
+
+  describe('when distribution type is "all"', () => {
+    const allDistributionType = new Set(['all']);
+
+    it('the body text contains only the "all" checksum value', () => {
+      const {title, body} = pullRequestText(
+        allDistributionType,
+        targetRelease,
+        sourceVersion
+      );
+
+      expect(title).toEqual('Updates Gradle Wrapper from 1.0.0 to 1.0.1');
+
+      expect(body).toEqual(`Updates Gradle Wrapper from 1.0.0 to 1.0.1.
+
+Read the release notes: https://docs.gradle.org/1.0.1/release-notes.html
+
+---
+
+The checksums of the Wrapper JAR and the distribution binary have been successfully verified.
+
+- Gradle release: \`1.0.1\`
+- Distribution (-all) zip checksum: \`dist-all-checksum-value\`
+- Wrapper JAR Checksum: \`wrapper-jar-checksum-value\`
+
+You can find the reference checksum values at https://gradle.org/release-checksums/
+
+---
+
+🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.
+
+<details>
+<summary>Need help? 🤔</summary>
+<br />
+
+If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
+</details>`);
+    });
+  });
+});


### PR DESCRIPTION
Change the PR body copy to include information about the target release
and a link to the official Release Checksums page.

Closes #72