### PR TITLE
Report errors about review requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,14 +172,14 @@ into your repository.
 
 Request a review from these GitHub usernames (notifications will be triggered).
 
-For example:
+For example, use a comma-separated list:
 
 ```yaml
 with:
   reviewers: username1, username2
 ```
 
-or
+or add each reviewer on a different line (no comma needed):
 
 ```yaml
 with:
@@ -187,6 +187,8 @@ with:
     username1
     username2
 ```
+
+Note that if you're using a Personal Access Token (PAT) as `repo-token` you cannot request a review from the user that the PAT belongs to.
 
 ---
 
@@ -198,12 +200,14 @@ with:
 
 Add custom labels to the Pull Request.
 
+For example, use a comma-separated list:
+
 ```yaml
 with:
   labels: automated pr, dependencies
 ```
 
-or
+or add each label on a different line (no comma needed):
 
 ```yaml
 with:
@@ -211,6 +215,8 @@ with:
     automated pr
     dependencies
 ```
+
+Label names can include spaces. Note that the action will create a label if it doesn't already exist within your organisation.
 
 ---
 

--- a/src/github/gh-ops.ts
+++ b/src/github/gh-ops.ts
@@ -18,6 +18,7 @@ import * as core from '@actions/core';
 
 import {GitHubApi, IGitHubApi} from './gh-api';
 import {Inputs} from '../inputs';
+import {PullRequestData} from '../store';
 import {pullRequestText} from '../messages';
 import {Release} from '../releases';
 
@@ -61,7 +62,7 @@ export class GitHubOps {
     distTypes: Set<string>,
     targetRelease: Release,
     sourceVersion?: string
-  ): Promise<string> {
+  ): Promise<PullRequestData> {
     const targetBranch =
       this.inputs.targetBranch !== ''
         ? this.inputs.targetBranch
@@ -94,6 +95,9 @@ export class GitHubOps {
 
     await this.api.addReviewers(pullRequest.number, this.inputs.reviewers);
 
-    return pullRequest.html_url;
+    return {
+      url: pullRequest.html_url,
+      number: pullRequest.number
+    };
   }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,18 +14,28 @@
 
 import * as core from '@actions/core';
 
-export function setActionMainCompleted() {
-  core.saveState('main-completed', 'true');
+const PULL_REQUEST_DATA = 'pull_request_data';
+const ERRORED_REVIEWERS = 'errored_reviewers';
+
+export interface PullRequestData {
+  url: string;
+  number: number;
 }
 
-export function isMainActionCompleted(): boolean {
-  return core.getState('main-completed') === 'true';
+export function setPullRequestData(pullRequestData: PullRequestData) {
+  core.saveState(PULL_REQUEST_DATA, JSON.stringify(pullRequestData));
+}
+
+export function getPullRequestData(): PullRequestData | undefined {
+  const state = core.getState(PULL_REQUEST_DATA);
+  return state.length ? (JSON.parse(state) as PullRequestData) : undefined;
 }
 
 export function setErroredReviewers(reviewers: string[]) {
-  core.saveState('errored-reviewers', JSON.stringify(reviewers));
+  core.saveState(ERRORED_REVIEWERS, JSON.stringify(reviewers));
 }
 
-export function getErroredReviewers(): string[] {
-  return JSON.parse(core.getState('errored-reviewers')) as string[];
+export function getErroredReviewers(): string[] | undefined {
+  const reviewers = core.getState(ERRORED_REVIEWERS);
+  return reviewers.length ? (JSON.parse(reviewers) as string[]) : undefined;
 }

--- a/src/tasks/main.ts
+++ b/src/tasks/main.ts
@@ -1,0 +1,170 @@
+// Copyright 2020-2021 Cristian Greco
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as core from '@actions/core';
+import * as glob from '@actions/glob';
+
+import {commit} from '../git-commit';
+import {getInputs} from '../inputs';
+import {GitHubOps} from '../github/gh-ops';
+import {Releases} from '../releases';
+import {WrapperInfo} from '../wrapperInfo';
+import {WrapperUpdater} from '../wrapperUpdater';
+import * as git from '../git-cmds';
+import * as store from '../store';
+
+/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+const currentCommitSha = process.env.GITHUB_SHA!;
+
+export async function runMain() {
+  try {
+    if (core.isDebug()) {
+      core.debug(JSON.stringify(process.env, null, 2));
+    }
+
+    const inputs = getInputs();
+
+    const targetRelease = await new Releases().current();
+    core.info(`Latest release: ${targetRelease.version}`);
+
+    const githubOps = new GitHubOps(inputs);
+
+    const ref = await githubOps.findMatchingRef(targetRelease.version);
+
+    if (ref) {
+      core.info('Found an existing ref, stopping here.');
+      core.debug(`Ref url: ${ref.url}`);
+      core.debug(`Ref sha: ${ref.object.sha}`);
+      core.warning(
+        `A pull request already exists that updates Gradle Wrapper to ${targetRelease.version}.`
+      );
+      return;
+    }
+
+    const globber = await glob.create(
+      '**/gradle/wrapper/gradle-wrapper.properties',
+      {followSymbolicLinks: false}
+    );
+    const wrappers = await globber.glob();
+    core.debug(`Wrappers: ${JSON.stringify(wrappers, null, 2)}`);
+
+    if (!wrappers.length) {
+      core.warning('Unable to find Gradle Wrapper files in this project.');
+      return;
+    }
+
+    core.debug(`Wrappers count: ${wrappers.length}`);
+
+    const wrapperInfos = wrappers.map(path => new WrapperInfo(path));
+
+    const commitDataList: {
+      files: string[];
+      targetVersion: string;
+      sourceVersion: string;
+    }[] = [];
+
+    await git.config('user.name', 'gradle-update-robot');
+    await git.config('user.email', 'gradle-update-robot@regolo.cc');
+
+    core.startGroup('Creating branch');
+    const branchName = `gradlew-update-${targetRelease.version}`;
+    await git.checkout(branchName, currentCommitSha);
+    core.endGroup();
+
+    const distTypes = new Set<string>();
+
+    for (const wrapper of wrapperInfos) {
+      core.startGroup(`Working with Wrapper at: ${wrapper.path}`);
+
+      // read current version before updating the wrapper
+      core.debug(`Current Wrapper version: ${wrapper.version}`);
+
+      if (wrapper.version === targetRelease.version) {
+        core.info(`Wrapper is already up-to-date`);
+        continue;
+      }
+
+      distTypes.add(wrapper.distType);
+
+      const updater = new WrapperUpdater(
+        wrapper,
+        targetRelease,
+        inputs.setDistributionChecksum
+      );
+
+      core.startGroup('Updating Wrapper');
+      await updater.update();
+      core.endGroup();
+
+      core.startGroup('Checking whether any file has been updated');
+      const modifiedFiles = await git.gitDiffNameOnly();
+      core.debug(`Modified files count: ${modifiedFiles.length}`);
+      core.debug(`Modified files list: ${modifiedFiles}`);
+      core.endGroup();
+
+      if (modifiedFiles.length) {
+        core.startGroup('Verifying Wrapper');
+        await updater.verify();
+        core.endGroup();
+
+        core.startGroup('Committing');
+        await commit(modifiedFiles, targetRelease.version, wrapper.version);
+        core.endGroup();
+
+        commitDataList.push({
+          files: modifiedFiles,
+          targetVersion: targetRelease.version,
+          sourceVersion: wrapper.version
+        });
+      } else {
+        core.info(`Nothing to update for Wrapper at ${wrapper.path}`);
+      }
+
+      core.endGroup();
+    }
+
+    if (!commitDataList.length) {
+      core.warning(
+        `✅ Gradle Wrapper is already up-to-date (version ${targetRelease.version})! 👍`
+      );
+      return;
+    }
+
+    const changedFilesCount = commitDataList
+      .map(cd => cd.files.length)
+      .reduce((acc, item) => acc + item);
+    core.debug(
+      `Have added ${commitDataList.length} commits for a total of ${changedFilesCount} files`
+    );
+
+    core.info('Pushing branch');
+    await git.push(branchName);
+
+    core.info('Creating Pull Request');
+    const pullRequestData = await githubOps.createPullRequest(
+      branchName,
+      distTypes,
+      targetRelease,
+      commitDataList.length === 1 ? commitDataList[0].sourceVersion : undefined
+    );
+
+    core.info(`✅ Created a Pull Request at ${pullRequestData.url} ✨`);
+
+    store.setPullRequestData(pullRequestData);
+  } catch (error) {
+    // setFailed is fatal (terminates action), core.error
+    // creates a failure annotation instead
+    core.setFailed(`❌ ${error.message}`);
+  }
+}

--- a/src/tasks/post.ts
+++ b/src/tasks/post.ts
@@ -1,0 +1,59 @@
+// Copyright 2020-2021 Cristian Greco
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as core from '@actions/core';
+
+import {IGitHubApi} from '../github/gh-api';
+import * as store from '../store';
+
+export class PostAction {
+  private githubApi: IGitHubApi;
+  private pullRequestData: store.PullRequestData;
+
+  constructor(githubApi: IGitHubApi, pullRequestData: store.PullRequestData) {
+    this.githubApi = githubApi;
+    this.pullRequestData = pullRequestData;
+  }
+
+  async run() {
+    try {
+      await this.reportErroredReviewers();
+    } catch (error) {
+      core.debug(`post action task failed with: ${error.message}`);
+    }
+  }
+
+  private async reportErroredReviewers() {
+    const erroredReviewers = store.getErroredReviewers();
+
+    if (erroredReviewers?.length) {
+      let usernames = '';
+      for (const reviewer of erroredReviewers) {
+        usernames += `- @${reviewer} \n`;
+      }
+
+      const body = `Unable to set all the PR reviewers, check the following usernames are correct:
+
+${usernames}
+
+Please refer to the documentation for the [\`reviewers\`](https://github.com/gradle-update/update-gradle-wrapper-action#reviewers) input.
+
+---
+
+🤖 This is an automatic comment by the Update Gradle Wrapper action.`;
+
+      await this.githubApi.createComment(this.pullRequestData.number, body);
+    }
+  }
+}

--- a/tests/github/fixtures/add_reviewer_to_pr.ok.json
+++ b/tests/github/fixtures/add_reviewer_to_pr.ok.json
@@ -24,8 +24,12 @@
   "assignees": [],
   "requested_reviewers": [
     {
-      "login": "cristiangreco",
+      "login": "reviewer1",
       "id": 123123
+    },
+    {
+      "login": "reviewer2",
+      "id": 456456
     }
   ],
   "requested_teams": [],

--- a/tests/github/fixtures/create_comment.ok.json
+++ b/tests/github/fixtures/create_comment.ok.json
@@ -1,0 +1,16 @@
+{
+  "url": "https://api.github.com/repos/owner-name/repo-name/issues/comments/4242",
+  "html_url": "https://github.com/cristiangreco/gradle-test-project/pull/42#issuecomment-4242",
+  "issue_url": "https://api.github.com/repos/owner-name/repo-name/issues/42",
+  "id": 4242,
+  "node_id": "abc123",
+  "user": {
+      "login": "username",
+      "id": 123123,
+      "node_id": "abc123"
+  },
+  "created_at": "2021-01-16T20:31:52Z",
+  "updated_at": "2021-01-16T20:31:52Z",
+  "author_association": "OWNER",
+  "body": "test comment"
+}

--- a/tests/github/gh-ops.test.ts
+++ b/tests/github/gh-ops.test.ts
@@ -38,8 +38,9 @@ const defaultMockGitHubApi: IGitHubApi = {
   createPullRequest: jest.fn(),
   addReviewers: jest.fn(),
   addLabels: jest.fn(),
+  createLabelIfMissing: jest.fn(),
   createLabel: jest.fn(),
-  createLabelIfMissing: jest.fn()
+  createComment: jest.fn()
 };
 
 let mockInputs: Inputs;
@@ -90,8 +91,8 @@ describe('createPullRequest', () => {
       });
     });
 
-    it('creates a Pull Request and returns its url', async () => {
-      const pullRequestUrl = await githubOps.createPullRequest(
+    it('creates a Pull Request and returns its data', async () => {
+      const pullRequestData = await githubOps.createPullRequest(
         branchName,
         distributionTypes,
         targetRelease,
@@ -119,15 +120,17 @@ describe('createPullRequest', () => {
 
       expect(mockGitHubApi.addReviewers).toHaveBeenCalledWith(42, []);
 
-      expect(pullRequestUrl).toEqual(
+      expect(pullRequestData).toBeDefined();
+      expect(pullRequestData.url).toEqual(
         'https://github.com/owner-name/repo-name/pull/42'
       );
+      expect(pullRequestData.number).toEqual(42);
     });
 
     it('sets the input targetBranch', async () => {
       mockInputs.targetBranch = 'release-v2';
 
-      const pullRequestUrl = await githubOps.createPullRequest(
+      const pullRequestData = await githubOps.createPullRequest(
         branchName,
         distributionTypes,
         targetRelease,
@@ -155,15 +158,17 @@ describe('createPullRequest', () => {
 
       expect(mockGitHubApi.addReviewers).toHaveBeenCalledWith(42, []);
 
-      expect(pullRequestUrl).toEqual(
+      expect(pullRequestData).toBeDefined();
+      expect(pullRequestData.url).toEqual(
         'https://github.com/owner-name/repo-name/pull/42'
       );
+      expect(pullRequestData.number).toEqual(42);
     });
 
     it('adds the input reviewers', async () => {
       mockInputs.reviewers = ['username', 'collaborator'];
 
-      const pullRequestUrl = await githubOps.createPullRequest(
+      const pullRequestData = await githubOps.createPullRequest(
         branchName,
         distributionTypes,
         targetRelease,
@@ -194,15 +199,17 @@ describe('createPullRequest', () => {
         'collaborator'
       ]);
 
-      expect(pullRequestUrl).toEqual(
+      expect(pullRequestData).toBeDefined();
+      expect(pullRequestData.url).toEqual(
         'https://github.com/owner-name/repo-name/pull/42'
       );
+      expect(pullRequestData.number).toEqual(42);
     });
 
     it('adds the input labels', async () => {
       mockInputs.labels = ['custom-label', 'help wanted'];
 
-      const pullRequestUrl = await githubOps.createPullRequest(
+      const pullRequestData = await githubOps.createPullRequest(
         branchName,
         distributionTypes,
         targetRelease,
@@ -232,9 +239,11 @@ describe('createPullRequest', () => {
 
       expect(mockGitHubApi.addReviewers).toHaveBeenCalledWith(42, []);
 
-      expect(pullRequestUrl).toEqual(
+      expect(pullRequestData).toBeDefined();
+      expect(pullRequestData.url).toEqual(
         'https://github.com/owner-name/repo-name/pull/42'
       );
+      expect(pullRequestData.number).toEqual(42);
     });
   });
 

--- a/tests/store/store.test.ts
+++ b/tests/store/store.test.ts
@@ -16,33 +16,41 @@ import * as core from '@actions/core';
 
 import * as store from '../../src/store';
 
-describe('setActionMainCompleted', () => {
-  it('saves a state variable as "true" string', () => {
+describe('setPullRequestData', () => {
+  it('saves a state variable as json representation of input data', () => {
     const saveState = jest.spyOn(core, 'saveState');
 
-    store.setActionMainCompleted();
+    store.setPullRequestData({url: 'https://github.com/pull/42', number: 42});
 
-    expect(saveState).toHaveBeenCalledWith('main-completed', 'true');
+    expect(saveState).toHaveBeenCalledWith(
+      'pull_request_data',
+      '{"url":"https://github.com/pull/42","number":42}'
+    );
   });
 });
 
-describe('isMainActionCompleted', () => {
-  it('returns true if the state variable is the "true" string', () => {
-    const getState = jest.spyOn(core, 'getState').mockReturnValue('true');
+describe('getPullRequestData', () => {
+  it('returns undefined if the state variable is empty', () => {
+    const getState = jest.spyOn(core, 'getState').mockReturnValue('');
 
-    const isCompleted = store.isMainActionCompleted();
+    const pullRequestData = store.getPullRequestData();
 
-    expect(getState).toHaveBeenCalledWith('main-completed');
-    expect(isCompleted).toBe(true);
+    expect(getState).toHaveBeenCalledWith('pull_request_data');
+    expect(pullRequestData).toBeUndefined();
   });
 
-  it('returns false if the state variable is other than the "true" string', () => {
-    const getState = jest.spyOn(core, 'getState').mockReturnValue('something');
+  it('returns data if the state variable is set to valid json', () => {
+    const getState = jest
+      .spyOn(core, 'getState')
+      .mockReturnValue('{"url":"https://github.com/pull/42","number":42}');
 
-    const isCompleted = store.isMainActionCompleted();
+    const isCompleted = store.getPullRequestData();
 
-    expect(getState).toHaveBeenCalledWith('main-completed');
-    expect(isCompleted).toBe(false);
+    expect(getState).toHaveBeenCalledWith('pull_request_data');
+    expect(isCompleted).toEqual({
+      url: 'https://github.com/pull/42',
+      number: 42
+    });
   });
 });
 
@@ -52,7 +60,7 @@ describe('setErroredReviewers', () => {
 
     store.setErroredReviewers(['a', 'b']);
 
-    expect(saveState).toHaveBeenCalledWith('errored-reviewers', '["a","b"]');
+    expect(saveState).toHaveBeenCalledWith('errored_reviewers', '["a","b"]');
   });
 
   describe('when input is empty', () => {
@@ -61,18 +69,27 @@ describe('setErroredReviewers', () => {
 
       store.setErroredReviewers([]);
 
-      expect(saveState).toHaveBeenCalledWith('errored-reviewers', '[]');
+      expect(saveState).toHaveBeenCalledWith('errored_reviewers', '[]');
     });
   });
 });
 
 describe('getErroredReviewers', () => {
-  it('returns an array of strings from json state', () => {
+  it('returns undefined if the state variable is empty', () => {
+    const getState = jest.spyOn(core, 'getState').mockReturnValue('');
+
+    const pullRequestData = store.getErroredReviewers();
+
+    expect(getState).toHaveBeenCalledWith('errored_reviewers');
+    expect(pullRequestData).toBeUndefined();
+  });
+
+  it('returns an array of strings if the state variable is set to valid json', () => {
     const getState = jest.spyOn(core, 'getState').mockReturnValue('["a"]');
 
     const reviewers = store.getErroredReviewers();
 
     expect(reviewers).toEqual(['a']);
-    expect(getState).toHaveBeenCalledWith('errored-reviewers');
+    expect(getState).toHaveBeenCalledWith('errored_reviewers');
   });
 });

--- a/tests/tasks/post.test.ts
+++ b/tests/tasks/post.test.ts
@@ -1,0 +1,70 @@
+// Copyright 2020-2021 Cristian Greco
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PostAction} from '../../src/tasks/post';
+import {IGitHubApi} from '../../src/github/gh-api';
+import * as store from '../../src/store';
+
+let mockGitHubApi: IGitHubApi;
+let postAction: PostAction;
+
+const defaultMockGitHubApi: IGitHubApi = {
+  repoDefaultBranch: jest.fn(),
+  createPullRequest: jest.fn(),
+  addReviewers: jest.fn(),
+  addLabels: jest.fn(),
+  createLabelIfMissing: jest.fn(),
+  createLabel: jest.fn(),
+  createComment: jest.fn()
+};
+
+beforeEach(() => {
+  mockGitHubApi = Object.create(defaultMockGitHubApi);
+
+  postAction = new PostAction(mockGitHubApi, {
+    url: 'https://github.com/pull/42',
+    number: 42
+  });
+});
+
+describe('run', () => {
+  describe('when there are errored reviewers', () => {
+    beforeEach(() => {
+      jest.spyOn(store, 'getErroredReviewers').mockReturnValue(['username1']);
+    });
+
+    it('reports errored reviewers to a Pull Request comment', async () => {
+      await postAction.run();
+
+      expect(store.getErroredReviewers).toHaveBeenCalled();
+
+      expect(mockGitHubApi.createComment).toHaveBeenCalledWith(
+        42,
+        expect.stringContaining('username1')
+      );
+    });
+  });
+
+  describe('when there are no errored reviewers', () => {
+    it('does nothing', async () => {
+      jest.spyOn(store, 'getErroredReviewers').mockReturnValue([]);
+
+      await postAction.run();
+
+      expect(store.getErroredReviewers).toHaveBeenCalled();
+
+      expect(mockGitHubApi.createComment).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
When review requests fails, the failed usernames are saved in the action
state to be reported as error later. The post action entry point will
fetch the list of errored reviewers, if any, and report them in a PR
comment.

Here we also change the review request mechanism to use multiple API
calls instead of a single one (to better handle cases where one single
username among the many provided would cause the whole request to fail
and no review being assigned).

Additionally, main and post action code is splitted into separate files.