### PR TITLE
Make repo-token input not mandatory anymore.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,8 @@ branding:
 inputs:
   repo-token:
     description: 'Access token for the repository, e.g. `{{ secrets.GITHUB_TOKEN }}`.'
-    required: true
+    required: false
+    default: ${{ github.token }}
   reviewers:
     description: 'List of users to request a review from (comma or newline-separated).'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -670,9 +670,9 @@ function getInputs() {
 exports.getInputs = getInputs;
 class ActionInputs {
     constructor() {
-        this.repoToken = core.getInput('repo-token', { required: true }).trim();
+        this.repoToken = core.getInput('repo-token', { required: false }).trim();
         if (this.repoToken === '') {
-            throw new Error(`repo-token is required`);
+            throw new Error(`repo-token cannot be empty`);
         }
         this.reviewers = core
             .getInput('reviewers', { required: false })

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -36,9 +36,9 @@ class ActionInputs implements Inputs {
   setDistributionChecksum: boolean;
 
   constructor() {
-    this.repoToken = core.getInput('repo-token', {required: true}).trim();
+    this.repoToken = core.getInput('repo-token', {required: false}).trim();
     if (this.repoToken === '') {
-      throw new Error(`repo-token is required`);
+      throw new Error(`repo-token cannot be empty`);
     }
 
     this.reviewers = core


### PR DESCRIPTION
Default the repo-token input value to GITHUB_TOKEN, and better document
the use case of custom PAT tokens.

This change is backward compatible, so we can stay on v1.