### PR TITLE
Add base-branch input parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Request](https://user-images.githubusercontent.com/316923/93274006-8922ef80-f7b9
   - [`reviewers`](#reviewers)
   - [`team-reviewers`](#team-reviewers)
   - [`labels`](#labels)
+  - [`base-branch`](#base-branch)
   - [`target-branch`](#target-branch)
   - [`set-distribution-checksum`](#set-distribution-checksum)
 - [Examples](#examples)
@@ -128,7 +129,8 @@ This is the list of supported inputs:
 | [`reviewers`](#reviewers) | List of users to request a review from (comma or newline-separated). | No | (empty) |
 | [`team-reviewers`](#team-reviewers) | List of teams to request a review from (comma or newline-separated). | No | (empty) |
 | [`labels`](#labels) | 'List of labels to set on the Pull Request (comma or newline-separated). | No | (empty) |
-| [`target-branch`](#target-branch) | Branch to create Pull Requests against. | No | The default branch name of your repository. |
+| [`base-branch`](#base-branch) | Base branch where the action will run and update the Gradle Wrapper. | No | The default branch name of your repository. |
+| [`target-branch`](#target-branch) | Branch to create the Pull Request against. | No | The default branch name of your repository. |
 | [`set-distribution-checksum`](#set-distribution-checksum) | Whether to set the `distributionSha256Sum` property. | No | `true` |
 
 ---
@@ -259,13 +261,28 @@ Label names can include spaces. Note that the action will create a label if it d
 
 ---
 
+### `base-branch`
+
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| `base-branch` | Base branch where the action will run and update the Gradle Wrapper. | No | The default branch name of your repository. |
+
+The name of the branch used as a base when running the update process. The action will switch (i.e. `git checkout`) to this branch before updating the `gradle-wrapper.jar` file. By default the repository's "[default branch](https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/managing-the-default-branch-name-for-your-repositories)" is used (most commonly `master`).
+
+```yaml
+with:
+  base-branch: gradle-testing
+```
+
+---
+
 ### `target-branch`
 
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
 | `target-branch` | Branch to create Pull Requests against. | No | The default branch name of your repository. |
 
-The name of the branch to pull changes into. By default the repository's "[default branch](https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/managing-the-default-branch-name-for-your-repositories)" is used (most commonly `master`).
+The name of the branch to push changes into. By default the repository's "[default branch](https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/managing-the-default-branch-name-for-your-repositories)" is used (most commonly `master`).
 
 For example:
 

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,11 @@ inputs:
     description: 'List of labels to set on the Pull Request (comma or newline-separated).'
     required: false
     default: ''
+  base-branch:
+    description: 'Base branch where the action will run and update the Gradle Wrapper.'
+    required: false
   target-branch:
-    description: 'Branch to create pull requests against.'
+    description: 'Branch to create the Pull Request against.'
     required: false
   set-distribution-checksum:
     description: 'Whether to set the `distributionSha256Sum` property in `gradle-wrapper.properties`.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -159,7 +159,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.push = exports.unsetConfig = exports.config = exports.commit = exports.add = exports.checkout = exports.gitDiffNameOnly = void 0;
+exports.push = exports.unsetConfig = exports.config = exports.commit = exports.add = exports.checkoutCreateBranch = exports.checkout = exports.fetch = exports.parseHead = exports.gitDiffNameOnly = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const cmd = __importStar(__nccwpck_require__(816));
 function gitDiffNameOnly() {
@@ -171,12 +171,35 @@ function gitDiffNameOnly() {
     });
 }
 exports.gitDiffNameOnly = gitDiffNameOnly;
-function checkout(branchName, startPoint) {
+function parseHead() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { stdout: currentCommitSha } = yield cmd.execWithOutput('git', [
+            'rev-parse',
+            'HEAD'
+        ]);
+        return currentCommitSha;
+    });
+}
+exports.parseHead = parseHead;
+function fetch() {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield cmd.execWithOutput('git', ['fetch', '--depth=1']);
+    });
+}
+exports.fetch = fetch;
+function checkout(branchName) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const exec = yield cmd.execWithOutput('git', ['checkout', branchName]);
+        return exec.exitCode;
+    });
+}
+exports.checkout = checkout;
+function checkoutCreateBranch(branchName, startPoint) {
     return __awaiter(this, void 0, void 0, function* () {
         yield cmd.execWithOutput('git', ['checkout', '-b', branchName, startPoint]);
     });
 }
-exports.checkout = checkout;
+exports.checkoutCreateBranch = checkoutCreateBranch;
 function add(paths) {
     return __awaiter(this, void 0, void 0, function* () {
         yield cmd.execWithOutput('git', ['add', ...paths]);
@@ -618,18 +641,21 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+const releases_1 = __nccwpck_require__(5715);
 const inputs_1 = __nccwpck_require__(4629);
 const gh_api_1 = __nccwpck_require__(3422);
-const post_1 = __nccwpck_require__(1645);
+const gh_ops_1 = __nccwpck_require__(1288);
 const main_1 = __nccwpck_require__(8888);
+const post_1 = __nccwpck_require__(1645);
 const store = __importStar(__nccwpck_require__(5826));
+const inputs = inputs_1.getInputs();
+const githubApi = new gh_api_1.GitHubApi(inputs.repoToken);
 if (!store.mainActionExecuted()) {
-    main_1.runMain();
+    new main_1.MainAction(inputs, githubApi, new gh_ops_1.GitHubOps(inputs), new releases_1.Releases()).run();
 }
 else {
     const pullRequestData = store.getPullRequestData();
     if (pullRequestData) {
-        const githubApi = new gh_api_1.GitHubApi(inputs_1.getInputs().repoToken);
         new post_1.PostAction(githubApi, pullRequestData).run();
     }
 }
@@ -692,6 +718,7 @@ class ActionInputs {
             .split(/[\n,]/)
             .map(l => l.trim())
             .filter(l => l.length);
+        this.baseBranch = core.getInput('base-branch', { required: false }).trim();
         this.targetBranch = core
             .getInput('target-branch', { required: false })
             .trim();
@@ -940,112 +967,130 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.runMain = void 0;
+exports.MainAction = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const glob = __importStar(__nccwpck_require__(8090));
 const git_commit_1 = __nccwpck_require__(4779);
-const inputs_1 = __nccwpck_require__(4629);
-const gh_ops_1 = __nccwpck_require__(1288);
-const releases_1 = __nccwpck_require__(5715);
 const wrapperInfo_1 = __nccwpck_require__(6832);
 const wrapperUpdater_1 = __nccwpck_require__(7412);
 const git = __importStar(__nccwpck_require__(8940));
 const gitAuth = __importStar(__nccwpck_require__(1304));
 const store = __importStar(__nccwpck_require__(5826));
-const currentCommitSha = process.env.GITHUB_SHA;
-function runMain() {
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            store.setMainActionExecuted();
-            if (core.isDebug()) {
+class MainAction {
+    constructor(inputs, githubApi, githubOps, releases) {
+        this.inputs = inputs;
+        this.githubApi = githubApi;
+        this.githubOps = githubOps;
+        this.releases = releases;
+    }
+    run() {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                store.setMainActionExecuted();
                 core.debug(JSON.stringify(process.env, null, 2));
-            }
-            const inputs = inputs_1.getInputs();
-            yield gitAuth.setup(inputs);
-            const targetRelease = yield new releases_1.Releases().current();
-            core.info(`Latest release: ${targetRelease.version}`);
-            const githubOps = new gh_ops_1.GitHubOps(inputs);
-            const ref = yield githubOps.findMatchingRef(targetRelease.version);
-            if (ref) {
-                core.info('Found an existing ref, stopping here.');
-                core.debug(`Ref url: ${ref.url}`);
-                core.debug(`Ref sha: ${ref.object.sha}`);
-                core.warning(`A pull request already exists that updates Gradle Wrapper to ${targetRelease.version}.`);
-                return;
-            }
-            const globber = yield glob.create('**/gradle/wrapper/gradle-wrapper.properties', { followSymbolicLinks: false });
-            const wrappers = yield globber.glob();
-            core.debug(`Wrappers: ${JSON.stringify(wrappers, null, 2)}`);
-            if (!wrappers.length) {
-                core.warning('Unable to find Gradle Wrapper files in this project.');
-                return;
-            }
-            core.debug(`Wrappers count: ${wrappers.length}`);
-            const wrapperInfos = wrappers.map(path => new wrapperInfo_1.WrapperInfo(path));
-            const commitDataList = [];
-            yield git.config('user.name', 'gradle-update-robot');
-            yield git.config('user.email', 'gradle-update-robot@regolo.cc');
-            core.startGroup('Creating branch');
-            const branchName = `gradlew-update-${targetRelease.version}`;
-            yield git.checkout(branchName, currentCommitSha);
-            core.endGroup();
-            const distTypes = new Set();
-            for (const wrapper of wrapperInfos) {
-                core.startGroup(`Working with Wrapper at: ${wrapper.path}`);
-                core.debug(`Current Wrapper version: ${wrapper.version}`);
-                if (wrapper.version === targetRelease.version) {
-                    core.info(`Wrapper is already up-to-date`);
-                    continue;
+                yield gitAuth.setup(this.inputs);
+                const targetRelease = yield this.releases.current();
+                core.info(`Latest release: ${targetRelease.version}`);
+                const ref = yield this.githubOps.findMatchingRef(targetRelease.version);
+                if (ref) {
+                    core.info('Found an existing ref, stopping here.');
+                    core.debug(`Ref url: ${ref.url}`);
+                    core.debug(`Ref sha: ${ref.object.sha}`);
+                    core.warning(`A pull request already exists that updates Gradle Wrapper to ${targetRelease.version}.`);
+                    return;
                 }
-                distTypes.add(wrapper.distType);
-                const updater = new wrapperUpdater_1.WrapperUpdater(wrapper, targetRelease, inputs.setDistributionChecksum);
-                core.startGroup('Updating Wrapper');
-                yield updater.update();
+                const globber = yield glob.create('**/gradle/wrapper/gradle-wrapper.properties', { followSymbolicLinks: false });
+                const wrappers = yield globber.glob();
+                core.debug(`Wrappers: ${JSON.stringify(wrappers, null, 2)}`);
+                if (!wrappers.length) {
+                    core.warning('Unable to find Gradle Wrapper files in this project.');
+                    return;
+                }
+                core.debug(`Wrappers count: ${wrappers.length}`);
+                const wrapperInfos = wrappers.map(path => wrapperInfo_1.createWrapperInfo(path));
+                const commitDataList = [];
+                yield git.config('user.name', 'gradle-update-robot');
+                yield git.config('user.email', 'gradle-update-robot@regolo.cc');
+                const baseBranch = this.inputs.baseBranch !== ''
+                    ? this.inputs.baseBranch
+                    : yield this.githubApi.repoDefaultBranch();
+                core.debug(`Base branch: ${baseBranch}`);
+                yield this.switchBranch(baseBranch);
+                const currentCommitSha = yield git.parseHead();
+                core.debug(`Head for branch ${baseBranch} is at ${currentCommitSha}`);
+                core.startGroup('Creating branch');
+                const branchName = `gradlew-update-${targetRelease.version}`;
+                yield git.checkoutCreateBranch(branchName, currentCommitSha);
                 core.endGroup();
-                core.startGroup('Checking whether any file has been updated');
-                const modifiedFiles = yield git.gitDiffNameOnly();
-                core.debug(`Modified files count: ${modifiedFiles.length}`);
-                core.debug(`Modified files list: ${modifiedFiles}`);
-                core.endGroup();
-                if (modifiedFiles.length) {
-                    core.startGroup('Verifying Wrapper');
-                    yield updater.verify();
+                const distTypes = new Set();
+                for (const wrapper of wrapperInfos) {
+                    core.startGroup(`Working with Wrapper at: ${wrapper.path}`);
+                    core.debug(`Current Wrapper version: ${wrapper.version}`);
+                    if (wrapper.version === targetRelease.version) {
+                        core.info(`Wrapper is already up-to-date`);
+                        continue;
+                    }
+                    distTypes.add(wrapper.distType);
+                    const updater = wrapperUpdater_1.createWrapperUpdater(wrapper, targetRelease, this.inputs.setDistributionChecksum);
+                    core.startGroup('Updating Wrapper');
+                    yield updater.update();
                     core.endGroup();
-                    core.startGroup('Committing');
-                    yield git_commit_1.commit(modifiedFiles, targetRelease.version, wrapper.version);
+                    core.startGroup('Checking whether any file has been updated');
+                    const modifiedFiles = yield git.gitDiffNameOnly();
+                    core.debug(`Modified files count: ${modifiedFiles.length}`);
+                    core.debug(`Modified files list: ${modifiedFiles}`);
                     core.endGroup();
-                    commitDataList.push({
-                        files: modifiedFiles,
-                        targetVersion: targetRelease.version,
-                        sourceVersion: wrapper.version
-                    });
+                    if (modifiedFiles.length) {
+                        core.startGroup('Verifying Wrapper');
+                        yield updater.verify();
+                        core.endGroup();
+                        core.startGroup('Committing');
+                        yield git_commit_1.commit(modifiedFiles, targetRelease.version, wrapper.version);
+                        core.endGroup();
+                        commitDataList.push({
+                            files: modifiedFiles,
+                            targetVersion: targetRelease.version,
+                            sourceVersion: wrapper.version
+                        });
+                    }
+                    else {
+                        core.info(`Nothing to update for Wrapper at ${wrapper.path}`);
+                    }
+                    core.endGroup();
                 }
-                else {
-                    core.info(`Nothing to update for Wrapper at ${wrapper.path}`);
+                if (!commitDataList.length) {
+                    core.warning(`✅ Gradle Wrapper is already up-to-date (version ${targetRelease.version})! 👍`);
+                    return;
                 }
-                core.endGroup();
+                const changedFilesCount = commitDataList
+                    .map(cd => cd.files.length)
+                    .reduce((acc, item) => acc + item);
+                core.debug(`Have added ${commitDataList.length} commits for a total of ${changedFilesCount} files`);
+                core.info('Pushing branch');
+                yield git.push(branchName);
+                core.info('Creating Pull Request');
+                const pullRequestData = yield this.githubOps.createPullRequest(branchName, distTypes, targetRelease, commitDataList.length === 1
+                    ? commitDataList[0].sourceVersion
+                    : undefined);
+                core.info(`✅ Created a Pull Request at ${pullRequestData.url} ✨`);
+                store.setPullRequestData(pullRequestData);
             }
-            if (!commitDataList.length) {
-                core.warning(`✅ Gradle Wrapper is already up-to-date (version ${targetRelease.version})! 👍`);
-                return;
+            catch (error) {
+                core.setFailed(`❌ ${error.message}`);
             }
-            const changedFilesCount = commitDataList
-                .map(cd => cd.files.length)
-                .reduce((acc, item) => acc + item);
-            core.debug(`Have added ${commitDataList.length} commits for a total of ${changedFilesCount} files`);
-            core.info('Pushing branch');
-            yield git.push(branchName);
-            core.info('Creating Pull Request');
-            const pullRequestData = yield githubOps.createPullRequest(branchName, distTypes, targetRelease, commitDataList.length === 1 ? commitDataList[0].sourceVersion : undefined);
-            core.info(`✅ Created a Pull Request at ${pullRequestData.url} ✨`);
-            store.setPullRequestData(pullRequestData);
-        }
-        catch (error) {
-            core.setFailed(`❌ ${error.message}`);
-        }
-    });
+        });
+    }
+    switchBranch(branchName) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield git.fetch();
+            const exitCode = yield git.checkout(branchName);
+            if (exitCode !== 0) {
+                throw new Error(`Invalid base branch ${branchName}`);
+            }
+        });
+    }
 }
-exports.runMain = runMain;
+exports.MainAction = MainAction;
 
 
 /***/ }),
@@ -1165,10 +1210,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.WrapperInfo = void 0;
+exports.createWrapperInfo = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const fs_1 = __nccwpck_require__(5747);
 const path_1 = __nccwpck_require__(5622);
+function createWrapperInfo(path) {
+    return new WrapperInfo(path);
+}
+exports.createWrapperInfo = createWrapperInfo;
 class WrapperInfo {
     constructor(path) {
         if (!path_1.isAbsolute(path)) {
@@ -1197,7 +1246,6 @@ class WrapperInfo {
         throw new Error('Unable to parse properties file');
     }
 }
-exports.WrapperInfo = WrapperInfo;
 
 
 /***/ }),
@@ -1236,9 +1284,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.WrapperUpdater = void 0;
+exports.createWrapperUpdater = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const cmd = __importStar(__nccwpck_require__(816));
+function createWrapperUpdater(wrapper, targetRelease, setDistributionChecksum) {
+    return new WrapperUpdater(wrapper, targetRelease, setDistributionChecksum);
+}
+exports.createWrapperUpdater = createWrapperUpdater;
 class WrapperUpdater {
     constructor(wrapper, targetRelease, setDistributionChecksum) {
         this.wrapper = wrapper;
@@ -1296,7 +1348,6 @@ class WrapperUpdater {
         });
     }
 }
-exports.WrapperUpdater = WrapperUpdater;
 
 
 /***/ }),

--- a/src/git/git-cmds.ts
+++ b/src/git/git-cmds.ts
@@ -25,7 +25,27 @@ export async function gitDiffNameOnly(): Promise<string[]> {
   return files;
 }
 
-export async function checkout(branchName: string, startPoint: string) {
+export async function parseHead(): Promise<string> {
+  const {stdout: currentCommitSha} = await cmd.execWithOutput('git', [
+    'rev-parse',
+    'HEAD'
+  ]);
+  return currentCommitSha;
+}
+
+export async function fetch() {
+  await cmd.execWithOutput('git', ['fetch', '--depth=1']);
+}
+
+export async function checkout(branchName: string): Promise<number> {
+  const exec = await cmd.execWithOutput('git', ['checkout', branchName]);
+  return exec.exitCode;
+}
+
+export async function checkoutCreateBranch(
+  branchName: string,
+  startPoint: string
+) {
   await cmd.execWithOutput('git', ['checkout', '-b', branchName, startPoint]);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,19 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {Releases} from './releases';
 import {getInputs} from './inputs';
 import {GitHubApi} from './github/gh-api';
+import {GitHubOps} from './github/gh-ops';
+import {MainAction} from './tasks/main';
 import {PostAction} from './tasks/post';
-import {runMain} from './tasks/main';
 import * as store from './store';
 
+const inputs = getInputs();
+const githubApi = new GitHubApi(inputs.repoToken);
+
 if (!store.mainActionExecuted()) {
-  runMain();
+  new MainAction(
+    inputs,
+    githubApi,
+    new GitHubOps(inputs),
+    new Releases()
+  ).run();
 } else {
   const pullRequestData = store.getPullRequestData();
 
   if (pullRequestData) {
-    const githubApi = new GitHubApi(getInputs().repoToken);
     new PostAction(githubApi, pullRequestData).run();
   }
 }

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -19,6 +19,7 @@ export interface Inputs {
   reviewers: string[];
   teamReviewers: string[];
   labels: string[];
+  baseBranch: string;
   targetBranch: string;
   setDistributionChecksum: boolean;
 }
@@ -32,6 +33,7 @@ class ActionInputs implements Inputs {
   reviewers: string[];
   teamReviewers: string[];
   labels: string[];
+  baseBranch: string;
   targetBranch: string;
   setDistributionChecksum: boolean;
 
@@ -61,6 +63,8 @@ class ActionInputs implements Inputs {
       .split(/[\n,]/)
       .map(l => l.trim())
       .filter(l => l.length);
+
+    this.baseBranch = core.getInput('base-branch', {required: false}).trim();
 
     this.targetBranch = core
       .getInput('target-branch', {required: false})

--- a/src/tasks/main.ts
+++ b/src/tasks/main.ts
@@ -16,160 +16,192 @@ import * as core from '@actions/core';
 import * as glob from '@actions/glob';
 
 import {commit} from '../git/git-commit';
-import {getInputs} from '../inputs';
+import {createWrapperInfo} from '../wrapperInfo';
+import {createWrapperUpdater} from '../wrapperUpdater';
 import {GitHubOps} from '../github/gh-ops';
+import {IGitHubApi} from '../github/gh-api';
+import {Inputs} from '../inputs';
 import {Releases} from '../releases';
-import {WrapperInfo} from '../wrapperInfo';
-import {WrapperUpdater} from '../wrapperUpdater';
 import * as git from '../git/git-cmds';
 import * as gitAuth from '../git/git-auth';
 import * as store from '../store';
 
-/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-const currentCommitSha = process.env.GITHUB_SHA!;
+export class MainAction {
+  private inputs: Inputs;
+  private githubApi: IGitHubApi;
+  private githubOps: GitHubOps;
+  private releases: Releases;
 
-export async function runMain() {
-  try {
-    store.setMainActionExecuted();
+  constructor(
+    inputs: Inputs,
+    githubApi: IGitHubApi,
+    githubOps: GitHubOps,
+    releases: Releases
+  ) {
+    this.inputs = inputs;
+    this.githubApi = githubApi;
+    this.githubOps = githubOps;
+    this.releases = releases;
+  }
 
-    if (core.isDebug()) {
+  async run() {
+    try {
+      store.setMainActionExecuted();
+
       core.debug(JSON.stringify(process.env, null, 2));
-    }
 
-    const inputs = getInputs();
+      await gitAuth.setup(this.inputs);
 
-    await gitAuth.setup(inputs);
+      const targetRelease = await this.releases.current();
+      core.info(`Latest release: ${targetRelease.version}`);
 
-    const targetRelease = await new Releases().current();
-    core.info(`Latest release: ${targetRelease.version}`);
+      const ref = await this.githubOps.findMatchingRef(targetRelease.version);
 
-    const githubOps = new GitHubOps(inputs);
-
-    const ref = await githubOps.findMatchingRef(targetRelease.version);
-
-    if (ref) {
-      core.info('Found an existing ref, stopping here.');
-      core.debug(`Ref url: ${ref.url}`);
-      core.debug(`Ref sha: ${ref.object.sha}`);
-      core.warning(
-        `A pull request already exists that updates Gradle Wrapper to ${targetRelease.version}.`
-      );
-      return;
-    }
-
-    const globber = await glob.create(
-      '**/gradle/wrapper/gradle-wrapper.properties',
-      {followSymbolicLinks: false}
-    );
-    const wrappers = await globber.glob();
-    core.debug(`Wrappers: ${JSON.stringify(wrappers, null, 2)}`);
-
-    if (!wrappers.length) {
-      core.warning('Unable to find Gradle Wrapper files in this project.');
-      return;
-    }
-
-    core.debug(`Wrappers count: ${wrappers.length}`);
-
-    const wrapperInfos = wrappers.map(path => new WrapperInfo(path));
-
-    const commitDataList: {
-      files: string[];
-      targetVersion: string;
-      sourceVersion: string;
-    }[] = [];
-
-    await git.config('user.name', 'gradle-update-robot');
-    await git.config('user.email', 'gradle-update-robot@regolo.cc');
-
-    core.startGroup('Creating branch');
-    const branchName = `gradlew-update-${targetRelease.version}`;
-    await git.checkout(branchName, currentCommitSha);
-    core.endGroup();
-
-    const distTypes = new Set<string>();
-
-    for (const wrapper of wrapperInfos) {
-      core.startGroup(`Working with Wrapper at: ${wrapper.path}`);
-
-      // read current version before updating the wrapper
-      core.debug(`Current Wrapper version: ${wrapper.version}`);
-
-      if (wrapper.version === targetRelease.version) {
-        core.info(`Wrapper is already up-to-date`);
-        continue;
+      if (ref) {
+        core.info('Found an existing ref, stopping here.');
+        core.debug(`Ref url: ${ref.url}`);
+        core.debug(`Ref sha: ${ref.object.sha}`);
+        core.warning(
+          `A pull request already exists that updates Gradle Wrapper to ${targetRelease.version}.`
+        );
+        return;
       }
 
-      distTypes.add(wrapper.distType);
+      const globber = await glob.create(
+        '**/gradle/wrapper/gradle-wrapper.properties',
+        {followSymbolicLinks: false}
+      );
+      const wrappers = await globber.glob();
+      core.debug(`Wrappers: ${JSON.stringify(wrappers, null, 2)}`);
 
-      const updater = new WrapperUpdater(
-        wrapper,
+      if (!wrappers.length) {
+        core.warning('Unable to find Gradle Wrapper files in this project.');
+        return;
+      }
+
+      core.debug(`Wrappers count: ${wrappers.length}`);
+
+      const wrapperInfos = wrappers.map(path => createWrapperInfo(path));
+
+      const commitDataList: {
+        files: string[];
+        targetVersion: string;
+        sourceVersion: string;
+      }[] = [];
+
+      await git.config('user.name', 'gradle-update-robot');
+      await git.config('user.email', 'gradle-update-robot@regolo.cc');
+
+      const baseBranch =
+        this.inputs.baseBranch !== ''
+          ? this.inputs.baseBranch
+          : await this.githubApi.repoDefaultBranch();
+      core.debug(`Base branch: ${baseBranch}`);
+
+      await this.switchBranch(baseBranch);
+
+      const currentCommitSha = await git.parseHead();
+      core.debug(`Head for branch ${baseBranch} is at ${currentCommitSha}`);
+
+      core.startGroup('Creating branch');
+      const branchName = `gradlew-update-${targetRelease.version}`;
+      await git.checkoutCreateBranch(branchName, currentCommitSha);
+      core.endGroup();
+
+      const distTypes = new Set<string>();
+
+      for (const wrapper of wrapperInfos) {
+        core.startGroup(`Working with Wrapper at: ${wrapper.path}`);
+
+        // read current version before updating the wrapper
+        core.debug(`Current Wrapper version: ${wrapper.version}`);
+
+        if (wrapper.version === targetRelease.version) {
+          core.info(`Wrapper is already up-to-date`);
+          continue;
+        }
+
+        distTypes.add(wrapper.distType);
+
+        const updater = createWrapperUpdater(
+          wrapper,
+          targetRelease,
+          this.inputs.setDistributionChecksum
+        );
+
+        core.startGroup('Updating Wrapper');
+        await updater.update();
+        core.endGroup();
+
+        core.startGroup('Checking whether any file has been updated');
+        const modifiedFiles = await git.gitDiffNameOnly();
+        core.debug(`Modified files count: ${modifiedFiles.length}`);
+        core.debug(`Modified files list: ${modifiedFiles}`);
+        core.endGroup();
+
+        if (modifiedFiles.length) {
+          core.startGroup('Verifying Wrapper');
+          await updater.verify();
+          core.endGroup();
+
+          core.startGroup('Committing');
+          await commit(modifiedFiles, targetRelease.version, wrapper.version);
+          core.endGroup();
+
+          commitDataList.push({
+            files: modifiedFiles,
+            targetVersion: targetRelease.version,
+            sourceVersion: wrapper.version
+          });
+        } else {
+          core.info(`Nothing to update for Wrapper at ${wrapper.path}`);
+        }
+
+        core.endGroup();
+      }
+
+      if (!commitDataList.length) {
+        core.warning(
+          `✅ Gradle Wrapper is already up-to-date (version ${targetRelease.version})! 👍`
+        );
+        return;
+      }
+
+      const changedFilesCount = commitDataList
+        .map(cd => cd.files.length)
+        .reduce((acc, item) => acc + item);
+      core.debug(
+        `Have added ${commitDataList.length} commits for a total of ${changedFilesCount} files`
+      );
+
+      core.info('Pushing branch');
+      await git.push(branchName);
+
+      core.info('Creating Pull Request');
+      const pullRequestData = await this.githubOps.createPullRequest(
+        branchName,
+        distTypes,
         targetRelease,
-        inputs.setDistributionChecksum
+        commitDataList.length === 1
+          ? commitDataList[0].sourceVersion
+          : undefined
       );
 
-      core.startGroup('Updating Wrapper');
-      await updater.update();
-      core.endGroup();
+      core.info(`✅ Created a Pull Request at ${pullRequestData.url} ✨`);
 
-      core.startGroup('Checking whether any file has been updated');
-      const modifiedFiles = await git.gitDiffNameOnly();
-      core.debug(`Modified files count: ${modifiedFiles.length}`);
-      core.debug(`Modified files list: ${modifiedFiles}`);
-      core.endGroup();
-
-      if (modifiedFiles.length) {
-        core.startGroup('Verifying Wrapper');
-        await updater.verify();
-        core.endGroup();
-
-        core.startGroup('Committing');
-        await commit(modifiedFiles, targetRelease.version, wrapper.version);
-        core.endGroup();
-
-        commitDataList.push({
-          files: modifiedFiles,
-          targetVersion: targetRelease.version,
-          sourceVersion: wrapper.version
-        });
-      } else {
-        core.info(`Nothing to update for Wrapper at ${wrapper.path}`);
-      }
-
-      core.endGroup();
+      store.setPullRequestData(pullRequestData);
+    } catch (error) {
+      // setFailed is fatal (terminates action), core.error
+      // creates a failure annotation instead
+      core.setFailed(`❌ ${error.message}`);
     }
+  }
 
-    if (!commitDataList.length) {
-      core.warning(
-        `✅ Gradle Wrapper is already up-to-date (version ${targetRelease.version})! 👍`
-      );
-      return;
+  private async switchBranch(branchName: string) {
+    await git.fetch();
+    const exitCode = await git.checkout(branchName);
+    if (exitCode !== 0) {
+      throw new Error(`Invalid base branch ${branchName}`);
     }
-
-    const changedFilesCount = commitDataList
-      .map(cd => cd.files.length)
-      .reduce((acc, item) => acc + item);
-    core.debug(
-      `Have added ${commitDataList.length} commits for a total of ${changedFilesCount} files`
-    );
-
-    core.info('Pushing branch');
-    await git.push(branchName);
-
-    core.info('Creating Pull Request');
-    const pullRequestData = await githubOps.createPullRequest(
-      branchName,
-      distTypes,
-      targetRelease,
-      commitDataList.length === 1 ? commitDataList[0].sourceVersion : undefined
-    );
-
-    core.info(`✅ Created a Pull Request at ${pullRequestData.url} ✨`);
-
-    store.setPullRequestData(pullRequestData);
-  } catch (error) {
-    // setFailed is fatal (terminates action), core.error
-    // creates a failure annotation instead
-    core.setFailed(`❌ ${error.message}`);
   }
 }

--- a/src/wrapperInfo.ts
+++ b/src/wrapperInfo.ts
@@ -17,7 +17,18 @@ import * as core from '@actions/core';
 import {readFileSync} from 'fs';
 import {isAbsolute} from 'path';
 
-export class WrapperInfo {
+export interface IWrapperInfo {
+  readonly version: string;
+  readonly path: string;
+  readonly distType: string;
+  readonly basePath: string;
+}
+
+export function createWrapperInfo(path: string): IWrapperInfo {
+  return new WrapperInfo(path);
+}
+
+class WrapperInfo implements IWrapperInfo {
   readonly version: string;
   readonly path: string;
   readonly distType: string;

--- a/src/wrapperUpdater.ts
+++ b/src/wrapperUpdater.ts
@@ -16,15 +16,28 @@ import * as core from '@actions/core';
 
 import * as cmd from './cmd';
 import type {Release} from './releases';
-import type {WrapperInfo} from './wrapperInfo';
+import type {IWrapperInfo} from './wrapperInfo';
 
-export class WrapperUpdater {
+export interface IWrapperUpdater {
+  update: () => Promise<void>;
+  verify: () => Promise<void>;
+}
+
+export function createWrapperUpdater(
+  wrapper: IWrapperInfo,
+  targetRelease: Release,
+  setDistributionChecksum: boolean
+): IWrapperUpdater {
+  return new WrapperUpdater(wrapper, targetRelease, setDistributionChecksum);
+}
+
+class WrapperUpdater implements IWrapperUpdater {
   private targetRelease: Release;
-  private wrapper: WrapperInfo;
+  private wrapper: IWrapperInfo;
   private setDistributionChecksum: boolean;
 
   constructor(
-    wrapper: WrapperInfo,
+    wrapper: IWrapperInfo,
     targetRelease: Release,
     setDistributionChecksum: boolean
   ) {

--- a/tests/git/git-cmds.test.ts
+++ b/tests/git/git-cmds.test.ts
@@ -49,11 +49,47 @@ describe('gitDiffNameOnly', () => {
   });
 });
 
-describe('checkout', () => {
-  it('execs "git checkout" with the given branch and start point', async () => {
+describe('parseHead', () => {
+  it('execs "git rev-parse" for current HEAD', async () => {
+    const exec = jest
+      .spyOn(cmd, 'execWithOutput')
+      .mockResolvedValue({exitCode: 0, stdout: 'abc123', stderr: ''});
+
+    const headSha = await git.parseHead();
+
+    expect(exec).toHaveBeenCalledWith('git', ['rev-parse', 'HEAD']);
+    expect(headSha).toEqual('abc123');
+  });
+});
+
+describe('fetch', () => {
+  it('execs "git fetch" with with depth option', async () => {
     const exec = jest.spyOn(cmd, 'execWithOutput').mockImplementation();
 
-    await git.checkout('main-branch', 'head-ref');
+    await git.fetch();
+
+    expect(exec).toHaveBeenCalledWith('git', ['fetch', '--depth=1']);
+  });
+});
+
+describe('checkout', () => {
+  it('execs "git checkout" with the given branch name and returns exit code', async () => {
+    const exec = jest
+      .spyOn(cmd, 'execWithOutput')
+      .mockResolvedValue({exitCode: 0, stdout: '', stderr: ''});
+
+    const exitCode = await git.checkout('main-branch');
+
+    expect(exec).toHaveBeenCalledWith('git', ['checkout', 'main-branch']);
+    expect(exitCode).toEqual(0);
+  });
+});
+
+describe('checkoutCreateBranch', () => {
+  it('execs "git checkout -b" with the given branch name and start point', async () => {
+    const exec = jest.spyOn(cmd, 'execWithOutput').mockImplementation();
+
+    await git.checkoutCreateBranch('main-branch', 'head-ref');
 
     expect(exec).toHaveBeenCalledWith('git', [
       'checkout',

--- a/tests/github/gh-ops.test.ts
+++ b/tests/github/gh-ops.test.ts
@@ -30,6 +30,7 @@ const defaultMockInputs: Inputs = {
   reviewers: [],
   teamReviewers: [],
   labels: [],
+  baseBranch: '',
   targetBranch: '',
   setDistributionChecksum: true
 };

--- a/tests/inputs/inputs.test.ts
+++ b/tests/inputs/inputs.test.ts
@@ -43,6 +43,7 @@ describe('getInputs', () => {
 
     expect(getInputs()).toMatchInlineSnapshot(`
       ActionInputs {
+        "baseBranch": "",
         "labels": Array [],
         "repoToken": "s3cr3t",
         "reviewers": Array [],
@@ -122,6 +123,44 @@ describe('getInputs', () => {
 
         expect(getInputs().labels).toStrictEqual(expected);
       }
+    });
+  });
+
+  describe('baseBranch', () => {
+    it('defaults to empty input', () => {
+      ymlInputs = {
+        'repo-token': 's3cr3t'
+      };
+
+      expect(getInputs().baseBranch).toStrictEqual('');
+    });
+
+    it('is set to the input string value', () => {
+      ymlInputs = {
+        'repo-token': 's3cr3t',
+        'base-branch': 'a-branch-name'
+      };
+
+      expect(getInputs().baseBranch).toStrictEqual('a-branch-name');
+    });
+  });
+
+  describe('targetBranch', () => {
+    it('defaults to empty input', () => {
+      ymlInputs = {
+        'repo-token': 's3cr3t'
+      };
+
+      expect(getInputs().targetBranch).toStrictEqual('');
+    });
+
+    it('is set to the input string value', () => {
+      ymlInputs = {
+        'repo-token': 's3cr3t',
+        'target-branch': 'a-branch-name'
+      };
+
+      expect(getInputs().targetBranch).toStrictEqual('a-branch-name');
     });
   });
 

--- a/tests/tasks/main.test.ts
+++ b/tests/tasks/main.test.ts
@@ -1,0 +1,174 @@
+// Copyright 2020-2021 Cristian Greco
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as glob from '@actions/glob';
+
+import {GitHubOps} from '../../src/github/gh-ops';
+import {IGitHubApi} from '../../src/github/gh-api';
+import {Inputs} from '../../src/inputs/';
+import {MainAction} from '../../src/tasks/main';
+import {Release, Releases} from '../../src/releases';
+import * as commit from '../../src/git/git-commit';
+import * as git from '../../src/git/git-cmds';
+import * as gitAuth from '../../src/git/git-auth';
+import * as store from '../../src/store';
+import * as wrapper from '../../src/wrapperInfo';
+import * as wrapperUpdater from '../../src/wrapperUpdater';
+
+let mainAction: MainAction;
+let mockInputs: Inputs;
+let mockGitHubApi: IGitHubApi;
+let mockGitHubOps: GitHubOps;
+let mockReleases: Releases;
+
+const defaultMockInputs: Inputs = {
+  repoToken: 's3cr3t',
+  reviewers: [],
+  teamReviewers: [],
+  labels: [],
+  baseBranch: '',
+  targetBranch: '',
+  setDistributionChecksum: true
+};
+
+const defaultMockGitHubApi: IGitHubApi = {
+  repoDefaultBranch: jest.fn(),
+  createPullRequest: jest.fn(),
+  addReviewers: jest.fn(),
+  addTeamReviewers: jest.fn(),
+  addLabels: jest.fn(),
+  createLabelIfMissing: jest.fn(),
+  createLabel: jest.fn(),
+  createComment: jest.fn()
+};
+
+beforeEach(() => {
+  mockInputs = Object.create(defaultMockInputs);
+  mockGitHubApi = Object.create(defaultMockGitHubApi);
+  mockGitHubOps = Object.create({
+    findMatchingRef: jest.fn(),
+    createPullRequest: jest.fn()
+  });
+  mockReleases = Object.create({
+    current: jest.fn()
+  });
+
+  mainAction = new MainAction(
+    mockInputs,
+    mockGitHubApi,
+    mockGitHubOps,
+    mockReleases
+  );
+});
+
+describe('run', () => {
+  it('creates a Pull Request to update wrapper files', async () => {
+    jest.spyOn(store, 'setMainActionExecuted').mockImplementation();
+
+    jest.spyOn(gitAuth, 'setup').mockImplementation();
+
+    mockReleases.current = jest.fn().mockReturnValue({
+      version: '1.0.1',
+      allChecksum: 'dist-all-checksum-value',
+      binChecksum: 'dist-bin-checksum-value',
+      wrapperChecksum: 'wrapper-jar-checksum-value'
+    } as Release);
+
+    mockGitHubOps.findMatchingRef = jest.fn().mockReturnValue(undefined);
+
+    jest.spyOn(glob, 'create').mockResolvedValue({
+      getSearchPaths: jest.fn(),
+      glob: jest
+        .fn()
+        .mockReturnValue(['/path/to/gradle/wrapper/gradle-wrapper.properties']),
+      globGenerator: jest.fn()
+    });
+
+    jest.spyOn(wrapper, 'createWrapperInfo').mockReturnValue({
+      version: '1.0.0',
+      path: '/path/to/gradle/wrapper/gradle-wrapper.properties',
+      distType: 'bin',
+      basePath: '/path/to/gradle'
+    } as wrapper.IWrapperInfo);
+
+    jest.spyOn(git, 'config').mockImplementation();
+
+    mockGitHubApi.repoDefaultBranch = jest.fn().mockReturnValue('master');
+
+    jest.spyOn(git, 'fetch').mockImplementation();
+    jest.spyOn(git, 'checkout').mockResolvedValue(0);
+    jest.spyOn(git, 'parseHead').mockResolvedValue('abc123');
+    jest.spyOn(git, 'checkoutCreateBranch').mockImplementation();
+
+    jest.spyOn(wrapperUpdater, 'createWrapperUpdater').mockReturnValue({
+      update: jest.fn().mockImplementation(),
+      verify: jest.fn().mockImplementation()
+    } as wrapperUpdater.IWrapperUpdater);
+
+    jest
+      .spyOn(git, 'gitDiffNameOnly')
+      .mockResolvedValue([
+        '/path/to/gradle/wrapper/gradle-wrapper.properties',
+        '/path/to/gradle/wrapper/gradle-wrapper.jar'
+      ]);
+
+    jest.spyOn(commit, 'commit').mockImplementation();
+
+    jest.spyOn(git, 'push').mockImplementation();
+
+    mockGitHubOps.createPullRequest = jest.fn().mockReturnValue({
+      url: 'https://github.com/owner/repo/pulls/42',
+      number: 42
+    } as store.PullRequestData);
+
+    jest.spyOn(store, 'setPullRequestData').mockImplementation();
+
+    await mainAction.run();
+
+    expect(store.setMainActionExecuted).toHaveBeenCalled();
+
+    expect(mockGitHubApi.repoDefaultBranch).toHaveBeenCalled();
+
+    expect(git.checkout).toHaveBeenCalledWith('master');
+    expect(git.checkoutCreateBranch).toHaveBeenCalledWith(
+      'gradlew-update-1.0.1',
+      'abc123'
+    );
+
+    expect(commit.commit).toHaveBeenCalledWith(
+      [
+        '/path/to/gradle/wrapper/gradle-wrapper.properties',
+        '/path/to/gradle/wrapper/gradle-wrapper.jar'
+      ],
+      '1.0.1',
+      '1.0.0'
+    );
+
+    expect(git.push).toHaveBeenCalledWith('gradlew-update-1.0.1');
+
+    expect(mockGitHubOps.createPullRequest).toHaveBeenCalledWith(
+      'gradlew-update-1.0.1',
+      new Set(['bin']),
+      expect.objectContaining({
+        version: '1.0.1'
+      }),
+      '1.0.0'
+    );
+
+    expect(store.setPullRequestData).toHaveBeenCalledWith({
+      url: 'https://github.com/owner/repo/pulls/42',
+      number: 42
+    });
+  });
+});

--- a/tests/wrapperInfo.test.ts
+++ b/tests/wrapperInfo.test.ts
@@ -14,12 +14,12 @@
 
 import * as path from 'path';
 
-import {WrapperInfo} from '../src/wrapperInfo';
+import {createWrapperInfo} from '../src/wrapperInfo';
 
 test('parses a valid properties file', () => {
   const propsPath = path.resolve('tests/data/gradle-wrapper.properties');
 
-  const wrapperInfo = new WrapperInfo(propsPath);
+  const wrapperInfo = createWrapperInfo(propsPath);
   expect(wrapperInfo.version).toBe('6.6.1');
   expect(wrapperInfo.distType).toBe('all');
 });


### PR DESCRIPTION
With `base-branch` one can set the branch to be checked out before running
any update operation. It defaults to the default branch of the repository.