### PR TITLE
Make sure wrapper jar is updated by running Gradle a second time.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1040,6 +1040,9 @@ class MainAction {
                     core.debug(`Modified files list: ${modifiedFiles}`);
                     core.endGroup();
                     if (modifiedFiles.length) {
+                        core.startGroup('Updating Wrapper (2nd update)');
+                        yield updater.update();
+                        core.endGroup();
                         core.startGroup('Verifying Wrapper');
                         yield updater.verify();
                         core.endGroup();
@@ -1311,7 +1314,7 @@ class WrapperUpdater {
                     : this.targetRelease.allChecksum;
                 args = args.concat(['--gradle-distribution-sha256-sum', sha256sum]);
             }
-            const { exitCode, stderr } = yield cmd.execWithOutput('gradle', args, this.wrapper.basePath);
+            const { exitCode, stderr } = yield cmd.execWithOutput('./gradlew', args, this.wrapper.basePath);
             if (exitCode !== 0) {
                 throw new Error(stderr);
             }

--- a/src/tasks/main.ts
+++ b/src/tasks/main.ts
@@ -140,6 +140,13 @@ export class MainAction {
         core.endGroup();
 
         if (modifiedFiles.length) {
+          // Running the `wrapper` task a second time ensures that the wrapper jar itself
+          // and the wrapper scripts get updated if a new version is available (happens infrequently).
+          // https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:upgrading_wrapper
+          core.startGroup('Updating Wrapper (2nd update)');
+          await updater.update();
+          core.endGroup();
+
           core.startGroup('Verifying Wrapper');
           await updater.verify();
           core.endGroup();

--- a/src/wrapperUpdater.ts
+++ b/src/wrapperUpdater.ts
@@ -67,7 +67,7 @@ class WrapperUpdater implements IWrapperUpdater {
     }
 
     const {exitCode, stderr} = await cmd.execWithOutput(
-      'gradle',
+      './gradlew',
       args,
       this.wrapper.basePath
     );


### PR DESCRIPTION
By design, the `wrapper` task only updates the `gradle-wrapper.properties`
file with distribution url and checksum of the new target gradle release.
However, in order to update the wrapper jar itself (and the shell scripts)
it's necessary to run the `wrapper` task a second time.

See https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:upgrading_wrapper

As part of this change we're also starting to run the `wrapper` task
using the `gradlew` script available in the project rather than the one
installed in the environment. This should open the door to better support
for updating to RC releases (see #188).

Closes #233