### PR TITLE
Include all changed files after the re-run of `wrapper` task.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1035,13 +1035,16 @@ class MainAction {
                     yield updater.update();
                     core.endGroup();
                     core.startGroup('Checking whether any file has been updated');
-                    const modifiedFiles = yield git.gitDiffNameOnly();
+                    let modifiedFiles = yield git.gitDiffNameOnly();
                     core.debug(`Modified files count: ${modifiedFiles.length}`);
                     core.debug(`Modified files list: ${modifiedFiles}`);
                     core.endGroup();
                     if (modifiedFiles.length) {
                         core.startGroup('Updating Wrapper (2nd update)');
                         yield updater.update();
+                        modifiedFiles = yield git.gitDiffNameOnly();
+                        core.debug(`Modified files count: ${modifiedFiles.length}`);
+                        core.debug(`Modified files list: ${modifiedFiles}`);
                         core.endGroup();
                         core.startGroup('Verifying Wrapper');
                         yield updater.verify();

--- a/src/tasks/main.ts
+++ b/src/tasks/main.ts
@@ -134,7 +134,7 @@ export class MainAction {
         core.endGroup();
 
         core.startGroup('Checking whether any file has been updated');
-        const modifiedFiles = await git.gitDiffNameOnly();
+        let modifiedFiles = await git.gitDiffNameOnly();
         core.debug(`Modified files count: ${modifiedFiles.length}`);
         core.debug(`Modified files list: ${modifiedFiles}`);
         core.endGroup();
@@ -145,6 +145,9 @@ export class MainAction {
           // https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:upgrading_wrapper
           core.startGroup('Updating Wrapper (2nd update)');
           await updater.update();
+          modifiedFiles = await git.gitDiffNameOnly();
+          core.debug(`Modified files count: ${modifiedFiles.length}`);
+          core.debug(`Modified files list: ${modifiedFiles}`);
           core.endGroup();
 
           core.startGroup('Verifying Wrapper');


### PR DESCRIPTION
Followup fix to #234, make sure that `gradle-wrapper.jar` and scripts
are included in the PR, if they have been modified due to the re-run of
the `wrapper` task.