### PR TITLE
Introduce `paths` and `paths-ignore` inputs.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: 'Whether to set the `distributionSha256Sum` property in `gradle-wrapper.properties`.'
     required: false
     default: true
+  paths:
+    description: 'List of paths where to search for Gradle Wrapper files (comma or newline-separated).'
+    required: false
+    default: ''
+  paths-ignore:
+    description: 'List of paths to be excluded when searching for Gradle Wrapper files (comma or newline-separated).'
+    required: false
+    default: ''
 
 runs:
   using: 'node16'

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -22,6 +22,8 @@ export interface Inputs {
   baseBranch: string;
   targetBranch: string;
   setDistributionChecksum: boolean;
+  paths: string[];
+  pathsIgnore: string[];
 }
 
 export function getInputs(): Inputs {
@@ -36,6 +38,8 @@ class ActionInputs implements Inputs {
   baseBranch: string;
   targetBranch: string;
   setDistributionChecksum: boolean;
+  paths: string[];
+  pathsIgnore: string[];
 
   constructor() {
     this.repoToken = core.getInput('repo-token', {required: false});
@@ -69,5 +73,17 @@ class ActionInputs implements Inputs {
       core
         .getInput('set-distribution-checksum', {required: false})
         .toLowerCase() !== 'false';
+
+    this.paths = core
+      .getInput('paths', {required: false})
+      .split(/[\n,]/)
+      .map(r => r.trim())
+      .filter(r => r.length);
+
+    this.pathsIgnore = core
+      .getInput('paths-ignore', {required: false})
+      .split(/[\n,]/)
+      .map(r => r.trim())
+      .filter(r => r.length);
   }
 }

--- a/src/tasks/main.ts
+++ b/src/tasks/main.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as core from '@actions/core';
-import * as glob from '@actions/glob';
 
 import * as git from '../git/git-cmds';
 import * as gitAuth from '../git/git-auth';
@@ -22,6 +21,7 @@ import * as store from '../store';
 import {commit} from '../git/git-commit';
 import {createWrapperInfo} from '../wrapperInfo';
 import {createWrapperUpdater} from '../wrapperUpdater';
+import {findWrapperPropertiesFiles} from '../wrapper/find';
 import {GitHubOps} from '../github/gh-ops';
 import {IGitHubApi} from '../github/gh-api';
 import {Inputs} from '../inputs';
@@ -68,11 +68,10 @@ export class MainAction {
         return;
       }
 
-      const globber = await glob.create(
-        '**/gradle/wrapper/gradle-wrapper.properties',
-        {followSymbolicLinks: false}
+      const wrappers = await findWrapperPropertiesFiles(
+        this.inputs.paths,
+        this.inputs.pathsIgnore
       );
-      const wrappers = await globber.glob();
       core.debug(`Wrappers: ${JSON.stringify(wrappers, null, 2)}`);
 
       if (!wrappers.length) {

--- a/src/wrapper/find.ts
+++ b/src/wrapper/find.ts
@@ -1,0 +1,99 @@
+// Copyright 2020-2021 Cristian Greco
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as core from '@actions/core';
+import * as glob from '@actions/glob';
+
+import {MatchKind} from '@actions/glob/lib/internal-match-kind';
+import {Pattern} from '@actions/glob/lib/internal-pattern';
+
+export async function findWrapperPropertiesFiles(
+  pathsInclude: string[],
+  pathsIgnore: string[]
+): Promise<string[]> {
+  const globber = await glob.create(
+    '**/gradle/wrapper/gradle-wrapper.properties',
+    {followSymbolicLinks: false}
+  );
+
+  let propertiesFiles = await globber.glob();
+
+  core.debug(
+    `wrapper.properties found: ${JSON.stringify(propertiesFiles, null, 2)}`
+  );
+
+  if (!propertiesFiles.length) {
+    return propertiesFiles;
+  }
+
+  if (pathsInclude.length) {
+    const toInclude: string[] = [];
+
+    for (const wrapperPath of propertiesFiles) {
+      let shouldInclude = false;
+
+      for (const searchPath of pathsInclude) {
+        const pattern = new Pattern(searchPath);
+        const match = pattern.match(wrapperPath);
+
+        shouldInclude ||= match === MatchKind.All;
+      }
+
+      if (shouldInclude) {
+        toInclude.push(wrapperPath);
+      }
+    }
+
+    propertiesFiles = toInclude;
+  }
+
+  core.debug(
+    `wrapper.properties after pathsInclude: ${JSON.stringify(
+      propertiesFiles,
+      null,
+      2
+    )}`
+  );
+
+  if (pathsIgnore.length) {
+    const toExclude: string[] = [];
+
+    for (const wrapperPath of propertiesFiles) {
+      let shouldExclude = false;
+
+      for (const searchPath of pathsIgnore) {
+        const pattern = new Pattern(searchPath);
+        const match = pattern.match(wrapperPath);
+
+        shouldExclude ||= match === MatchKind.All;
+      }
+
+      if (shouldExclude) {
+        toExclude.push(wrapperPath);
+      }
+    }
+
+    propertiesFiles = propertiesFiles.filter(f => !toExclude.includes(f));
+  }
+
+  core.debug(
+    `wrapper.properties after pathsExclude: ${JSON.stringify(
+      propertiesFiles,
+      null,
+      2
+    )}`
+  );
+
+  return propertiesFiles;
+}

--- a/tests/github/gh-ops.test.ts
+++ b/tests/github/gh-ops.test.ts
@@ -32,7 +32,9 @@ const defaultMockInputs: Inputs = {
   labels: [],
   baseBranch: '',
   targetBranch: '',
-  setDistributionChecksum: true
+  setDistributionChecksum: true,
+  paths: [],
+  pathsIgnore: []
 };
 
 const defaultMockGitHubApi: IGitHubApi = {

--- a/tests/inputs/inputs.test.ts
+++ b/tests/inputs/inputs.test.ts
@@ -45,6 +45,8 @@ describe('getInputs', () => {
       ActionInputs {
         "baseBranch": "",
         "labels": Array [],
+        "paths": Array [],
+        "pathsIgnore": Array [],
         "repoToken": "s3cr3t",
         "reviewers": Array [],
         "setDistributionChecksum": true,

--- a/tests/tasks/main.test.ts
+++ b/tests/tasks/main.test.ts
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as glob from '@actions/glob';
-
 import * as commit from '../../src/git/git-commit';
 import * as git from '../../src/git/git-cmds';
 import * as gitAuth from '../../src/git/git-auth';
 import * as store from '../../src/store';
 import * as wrapper from '../../src/wrapperInfo';
+import * as wrapperFind from '../../src/wrapper/find';
 import * as wrapperUpdater from '../../src/wrapperUpdater';
 
 import {GitHubOps} from '../../src/github/gh-ops';
@@ -40,7 +39,9 @@ const defaultMockInputs: Inputs = {
   labels: [],
   baseBranch: '',
   targetBranch: '',
-  setDistributionChecksum: true
+  setDistributionChecksum: true,
+  paths: [],
+  pathsIgnore: []
 };
 
 const defaultMockGitHubApi: IGitHubApi = {
@@ -88,13 +89,9 @@ describe('run', () => {
 
     mockGitHubOps.findMatchingRef = jest.fn().mockReturnValue(undefined);
 
-    jest.spyOn(glob, 'create').mockResolvedValue({
-      getSearchPaths: jest.fn(),
-      glob: jest
-        .fn()
-        .mockReturnValue(['/path/to/gradle/wrapper/gradle-wrapper.properties']),
-      globGenerator: jest.fn()
-    });
+    jest
+      .spyOn(wrapperFind, 'findWrapperPropertiesFiles')
+      .mockResolvedValue(['/path/to/gradle/wrapper/gradle-wrapper.properties']);
 
     jest.spyOn(wrapper, 'createWrapperInfo').mockReturnValue({
       version: '1.0.0',

--- a/tests/wrapper/find.test.ts
+++ b/tests/wrapper/find.test.ts
@@ -1,0 +1,89 @@
+// Copyright 2020-2021 Cristian Greco
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as glob from '@actions/glob';
+import * as path from 'path';
+
+import {findWrapperPropertiesFiles} from '../../src/wrapper/find';
+
+describe('findWrapperPropertiesFiles', () => {
+  it('filters paths based on include and ignore lists', async () => {
+    const pathPrefix = path.dirname(__filename);
+
+    jest.spyOn(glob, 'create').mockResolvedValue({
+      getSearchPaths: jest.fn(),
+      glob: jest
+        .fn()
+        .mockReturnValue([
+          `${pathPrefix}/path_a/gradle/wrapper/gradle-wrapper.properties`,
+          `${pathPrefix}/path_b/gradle/wrapper/gradle-wrapper.properties`,
+          `${pathPrefix}/path_b/subpath_c/gradle/wrapper/gradle-wrapper.properties`
+        ]),
+      globGenerator: jest.fn()
+    });
+
+    const tests: {
+      pathsInclude: string[];
+      pathsIgnore: string[];
+      pathsExpected: string[];
+    }[] = [
+      {
+        pathsInclude: [],
+        pathsIgnore: [],
+        pathsExpected: [
+          `${pathPrefix}/path_a/gradle/wrapper/gradle-wrapper.properties`,
+          `${pathPrefix}/path_b/gradle/wrapper/gradle-wrapper.properties`,
+          `${pathPrefix}/path_b/subpath_c/gradle/wrapper/gradle-wrapper.properties`
+        ]
+      },
+      {
+        pathsInclude: [`${pathPrefix}/path_a/**`],
+        pathsIgnore: [],
+        pathsExpected: [
+          `${pathPrefix}/path_a/gradle/wrapper/gradle-wrapper.properties`
+        ]
+      },
+      {
+        pathsInclude: [],
+        pathsIgnore: [`${pathPrefix}/path_a/**`],
+        pathsExpected: [
+          `${pathPrefix}/path_b/gradle/wrapper/gradle-wrapper.properties`,
+          `${pathPrefix}/path_b/subpath_c/gradle/wrapper/gradle-wrapper.properties`
+        ]
+      },
+      {
+        pathsInclude: [`${pathPrefix}/path_a/**`],
+        pathsIgnore: [`${pathPrefix}/path_a/**`],
+        pathsExpected: []
+      },
+      {
+        pathsInclude: [`${pathPrefix}/path_b/**`],
+        pathsIgnore: [`${pathPrefix}/path_b/subpath_c/**`],
+        pathsExpected: [
+          `${pathPrefix}/path_b/gradle/wrapper/gradle-wrapper.properties`
+        ]
+      }
+    ];
+
+    for (const t of tests) {
+      const files = await findWrapperPropertiesFiles(
+        t.pathsInclude,
+        t.pathsIgnore
+      );
+      expect(files).toEqual(t.pathsExpected);
+    }
+
+    expect(glob.create).toHaveBeenCalledTimes(tests.length);
+  });
+});


### PR DESCRIPTION
These inputs can be used to build an allowlist and blocklist of patterns
where the action searches for Gradle Wrapper files to be updated.