### PR TITLE
Fixing link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ with:
   repo-token: ${{ secrets.GRADLE_UPDATE_PAT }}
 ```
 
-Read this [paragraph]((#running-ci-workflows-in-pull-requests-created-by-the-action)) for more details on the topic.
+Read this [paragraph](#running-ci-workflows-in-pull-requests-created-by-the-action) for more details on the topic.
 
 ---
 


### PR DESCRIPTION
Currently, clicking on the link navigates to `https://github.com/gradle-update/update-gradle-wrapper-action/blob/master/(#running-ci-workflows-in-pull-requests-created-by-the-action)` which 404's.