### PR TITLE
Update actions/checkout to v3 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1


### PR DESCRIPTION
This PR updates `actions/checkout` to `v3` in the `README.md` file.