### PR TITLE
Adding auto-merge functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ This is the list of supported inputs:
 | [`paths-ignore`](#paths-ignore) | List of paths to be excluded when searching for Gradle Wrapper files (comma or newline-separated). | No | (empty) |
 | [`set-distribution-checksum`](#set-distribution-checksum) | Whether to set the `distributionSha256Sum` property. | No | `true` |
 | [`release-channel`](#release-channel) | Which Gradle release channel to use: either `stable` or `release-candidate`. | No | `stable` |
+| [`merge-method`](#merge-method) | Which merge method to use for [auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request). Valid values include `MERGE`, `REBASE`, or `SQUASH`.  If unset, automerge will not be enabled on opened PRs. | No | (unset) No auto-merge |
 
 ---
 
@@ -406,6 +407,20 @@ For example:
 ```yaml
 with:
   release-channel: release-candidate
+```
+### `merge-method`
+
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| [`merge-method`](#merge-method) | Which merge method to use for [auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request). Valid values include `MERGE`, `REBASE`, or `SQUASH`.  If unset, automerge will not be enabled on opened PRs. | No | (unset) No auto-merge |
+
+The merge method to use for [auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request). By default auto-merge will not be enabled; set this to one of the valid merge methods to enable auto-merge.
+
+For example:
+
+```yaml
+with:
+  merge-method: SQUASH
 ```
 
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,9 @@ inputs:
     description: 'Gradle release channel to be used (either `stable` or `release-candidate`).'
     required: false
     default: stable
+  merge-method:
+    description: 'Which merge method to use for auto-merge (either `MERGE`, `REBASE`, or `SQUASH`).  If unset, auto-merge will not be enabled on opened PRs.'
+    required: false
 
 runs:
   using: 'node16'

--- a/src/github/gh-ops.ts
+++ b/src/github/gh-ops.ts
@@ -101,6 +101,13 @@ export class GitHubOps {
       this.inputs.teamReviewers
     );
 
+    if (this.inputs.mergeMethod !== undefined) {
+      await this.api.enableAutoMerge(
+        pullRequest.number,
+        this.inputs.mergeMethod
+      );
+    }
+
     return {
       url: pullRequest.html_url,
       number: pullRequest.number

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -25,6 +25,7 @@ export interface Inputs {
   paths: string[];
   pathsIgnore: string[];
   releaseChannel: string;
+  mergeMethod: string | undefined;
 }
 
 export function getInputs(): Inputs {
@@ -44,6 +45,7 @@ class ActionInputs implements Inputs {
   paths: string[];
   pathsIgnore: string[];
   releaseChannel: string;
+  mergeMethod: string | undefined;
 
   constructor() {
     this.repoToken = core.getInput('repo-token', {required: false});
@@ -99,6 +101,11 @@ class ActionInputs implements Inputs {
     }
     if (!acceptedReleaseChannels.includes(this.releaseChannel)) {
       throw new Error('release-channel has unexpected value');
+    }
+
+    this.mergeMethod = core.getInput('merge-method', {required: false});
+    if (!this.mergeMethod) {
+      this.mergeMethod = undefined;
     }
   }
 }

--- a/tests/github/gh-ops.test.ts
+++ b/tests/github/gh-ops.test.ts
@@ -35,7 +35,8 @@ const defaultMockInputs: Inputs = {
   setDistributionChecksum: true,
   paths: [],
   pathsIgnore: [],
-  releaseChannel: ''
+  releaseChannel: '',
+  mergeMethod: undefined
 };
 
 const defaultMockGitHubApi: IGitHubApi = {
@@ -46,7 +47,8 @@ const defaultMockGitHubApi: IGitHubApi = {
   addLabels: jest.fn(),
   createLabelIfMissing: jest.fn(),
   createLabel: jest.fn(),
-  createComment: jest.fn()
+  createComment: jest.fn(),
+  enableAutoMerge: jest.fn()
 };
 
 let mockInputs: Inputs;

--- a/tests/inputs/inputs.test.ts
+++ b/tests/inputs/inputs.test.ts
@@ -45,6 +45,7 @@ describe('getInputs', () => {
       ActionInputs {
         "baseBranch": "",
         "labels": Array [],
+        "mergeMethod": undefined,
         "paths": Array [],
         "pathsIgnore": Array [],
         "releaseChannel": "stable",

--- a/tests/tasks/main.test.ts
+++ b/tests/tasks/main.test.ts
@@ -42,7 +42,8 @@ const defaultMockInputs: Inputs = {
   setDistributionChecksum: true,
   paths: [],
   pathsIgnore: [],
-  releaseChannel: ''
+  releaseChannel: '',
+  mergeMethod: undefined
 };
 
 const defaultMockGitHubApi: IGitHubApi = {
@@ -53,7 +54,8 @@ const defaultMockGitHubApi: IGitHubApi = {
   addLabels: jest.fn(),
   createLabelIfMissing: jest.fn(),
   createLabel: jest.fn(),
-  createComment: jest.fn()
+  createComment: jest.fn(),
+  enableAutoMerge: jest.fn()
 };
 
 beforeEach(() => {

--- a/tests/tasks/post.test.ts
+++ b/tests/tasks/post.test.ts
@@ -28,7 +28,8 @@ const defaultMockGitHubApi: IGitHubApi = {
   addLabels: jest.fn(),
   createLabelIfMissing: jest.fn(),
   createLabel: jest.fn(),
-  createComment: jest.fn()
+  createComment: jest.fn(),
+  enableAutoMerge: jest.fn()
 };
 
 beforeEach(() => {


### PR DESCRIPTION
# Summary

Adding auto-merge functionality

# Details

This PR introduces a feature to enable auto-merge on the PRs that this GitHub Action opens to update Gradle Wrapper.

# Integration Testing

I tested the changes in https://github.com/ChrisCarini/TEST-update-gradle-wrapper-action/actions/workflows/update-gradle-wrapper.yml - the following PRs were opened:

1. https://github.com/ChrisCarini/TEST-update-gradle-wrapper-action/pull/2
    - default user
    - no `merge-method` set
    - ✅ **Result:** 
        - auto-merge **was not** enabled on this PR **(expected)**
3. https://github.com/ChrisCarini/TEST-update-gradle-wrapper-action/pull/3
    - default user
    - `merge-method` set to `SQUASH`
    - ✅ **Result:**  
        - auto-merge **was** enabled on this PR **(expected)**
        - PR **was not** auto-merged. _(checks **did not** run because of default `GITHUB_TOKEN` was used; [as expected](https://github.com/gradle-update/update-gradle-wrapper-action#running-ci-workflows-in-pull-requests-created-by-the-action))_ **(expected)**
5. https://github.com/ChrisCarini/TEST-update-gradle-wrapper-action/pull/4
    - custom PAT
    - `merge-method` set to `SQUASH`
    - ✅ **Result:** 
        - auto-merge **was** enabled **(expected)**
        - PR was auto-merged _(checks **did** run because of custom PAT)_ **(expected)**

Resolves #120 