### PR TITLE
Enable CI checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  merge_group:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
Add `merge_group` condition to enable CI to run in merge queue.