### PR TITLE
Allow PR to be created if the bump breaks the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Request](https://user-images.githubusercontent.com/316923/93274006-8922ef80-f7b9
   - [`pr-title-template`](#pr-title-template)
   - [`pr-message-template`](#pr-message-template)
   - [`commit-message-template`](#commit-message-template)
+  - [`ignore-failure-after-update`](#ignore-failure-after-update)
 - [Examples](#examples)
   - [Scheduling action execution](#scheduling-action-execution)
   - [Targeting a custom branch](#targeting-a-custom-branch)
@@ -151,6 +152,7 @@ This is the list of supported inputs:
 | [`pr-title-template`](#pr-title-template) | The template to use for the title of the pull request created by this action | No | `Update Gradle Wrapper from %sourceVersion% to %targetVersion%` |
 | [`pr-message-template`](#pr-message-template) | The template to use for the description of the pull request created by this action | No | (empty) |
 | [`commit-message-template`](#commit-message-template) | The template to use for the commit message created by this action | No | `Update Gradle Wrapper from %sourceVersion% to %targetVersion%` |
+| [`ignore-failure-after-update`](#ignore-failure-after-update) | Whether to ignore build failures when updating the Gradle Wrapper and still create a Pull Request | No | `true` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Request](https://user-images.githubusercontent.com/316923/93274006-8922ef80-f7b9
   - [`pr-title-template`](#pr-title-template)
   - [`pr-message-template`](#pr-message-template)
   - [`commit-message-template`](#commit-message-template)
-  - [`ignore-failure-after-update`](#ignore-failure-after-update)
+  - [`ignore-update-failure`](#ignore-update-failure)
 - [Examples](#examples)
   - [Scheduling action execution](#scheduling-action-execution)
   - [Targeting a custom branch](#targeting-a-custom-branch)
@@ -152,7 +152,7 @@ This is the list of supported inputs:
 | [`pr-title-template`](#pr-title-template) | The template to use for the title of the pull request created by this action | No | `Update Gradle Wrapper from %sourceVersion% to %targetVersion%` |
 | [`pr-message-template`](#pr-message-template) | The template to use for the description of the pull request created by this action | No | (empty) |
 | [`commit-message-template`](#commit-message-template) | The template to use for the commit message created by this action | No | `Update Gradle Wrapper from %sourceVersion% to %targetVersion%` |
-| [`ignore-failure-after-update`](#ignore-failure-after-update) | Whether to ignore build failures when updating the Gradle Wrapper and still create a Pull Request | No | `true` |
+| [`ignore-update-failure`](#ignore-update-failure) | Whether to ignore build failures when updating the Gradle Wrapper and still create a Pull Request | No | `true` |
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ inputs:
       used to replace the source version placeholder.
     required: false
     default: 'Update Gradle Wrapper from %sourceVersion% to %targetVersion%'
-  ignore-failure-after-update:
+  ignore-update-failure:
     description: |
       Whether to ignore build failures when updating the Gradle Wrapper and still create a Pull Request.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,11 @@ inputs:
       used to replace the source version placeholder.
     required: false
     default: 'Update Gradle Wrapper from %sourceVersion% to %targetVersion%'
+  ignore-failure-after-update:
+    description: |
+      Whether to ignore build failures when updating the Gradle Wrapper and still create a Pull Request.
+    required: false
+    default: true
 
 runs:
   using: 'node20'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1351,17 +1351,7 @@ class MainAction {
                         core.debug(`Modified files list: ${modifiedFiles}`);
                         core.endGroup();
                         core.startGroup('Verifying Wrapper');
-                        try {
-                            yield updater.verify();
-                        }
-                        catch (ex) {
-                            if (this.inputs.ignoreUpdateFailure) {
-                                core.warning(ex instanceof Error ? ex : `${ex}`);
-                            }
-                            else {
-                                throw ex;
-                            }
-                        }
+                        yield updater.verify();
                         core.endGroup();
                         core.startGroup('Committing');
                         const commitMessage = (0, messages_1.replaceVersionPlaceholders)(this.inputs.commitMessageTemplate, wrapper.version, targetRelease.version);

--- a/dist/index.js
+++ b/dist/index.js
@@ -959,7 +959,9 @@ class ActionInputs {
             this.commitMessageTemplate =
                 'Update Gradle Wrapper from %sourceVersion% to %targetVersion%';
         }
-        this.ignoreFailureAfterUpdate = core.getBooleanInput('ignore-failure-after-update', { required: false });
+        this.ignoreUpdateFailure = core.getBooleanInput('ignore-update-failure', {
+            required: false
+        });
     }
 }
 
@@ -1335,7 +1337,7 @@ class MainAction {
                             yield updater.update();
                         }
                         catch (ex) {
-                            if (this.inputs.ignoreFailureAfterUpdate) {
+                            if (this.inputs.ignoreUpdateFailure) {
                                 buildBrokenAfterBump = true;
                                 core.warning(ex instanceof Error ? ex : `${ex}`);
                                 core.warning('Ignoring failure after 2nd update');
@@ -1353,7 +1355,7 @@ class MainAction {
                             yield updater.verify();
                         }
                         catch (ex) {
-                            if (this.inputs.ignoreFailureAfterUpdate) {
+                            if (this.inputs.ignoreUpdateFailure) {
                                 core.warning(ex instanceof Error ? ex : `${ex}`);
                             }
                             else {

--- a/src/github/gh-ops.ts
+++ b/src/github/gh-ops.ts
@@ -63,6 +63,7 @@ export class GitHubOps {
     branchName: string,
     distTypes: Set<string>,
     targetRelease: Release,
+    buildBrokenAfterBump: boolean,
     sourceVersion?: string
   ): Promise<PullRequestData> {
     const targetBranch =
@@ -92,6 +93,15 @@ export class GitHubOps {
         targetRelease,
         sourceVersion
       ));
+    }
+
+    if (buildBrokenAfterBump) {
+      body = `${body}
+      
+> [!CAUTION]
+> The Gradle bump has broken the build.
+> Remember to run \`./gradlew wrapper\` once the breaking changes are addressed
+`;
     }
 
     const pullRequest = await this.api.createPullRequest({

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -30,6 +30,7 @@ export interface Inputs {
   prTitleTemplate: string;
   prMessageTemplate: string;
   commitMessageTemplate: string;
+  ignoreFailureAfterUpdate: boolean;
 }
 
 export function getInputs(): Inputs {
@@ -54,6 +55,7 @@ class ActionInputs implements Inputs {
   prTitleTemplate: string;
   prMessageTemplate: string;
   commitMessageTemplate: string;
+  ignoreFailureAfterUpdate: boolean;
 
   constructor() {
     this.repoToken = core.getInput('repo-token', {required: false});
@@ -143,5 +145,10 @@ class ActionInputs implements Inputs {
       this.commitMessageTemplate =
         'Update Gradle Wrapper from %sourceVersion% to %targetVersion%';
     }
+
+    this.ignoreFailureAfterUpdate = core.getBooleanInput(
+      'ignore-failure-after-update',
+      {required: false}
+    );
   }
 }

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -30,7 +30,7 @@ export interface Inputs {
   prTitleTemplate: string;
   prMessageTemplate: string;
   commitMessageTemplate: string;
-  ignoreFailureAfterUpdate: boolean;
+  ignoreUpdateFailure: boolean;
 }
 
 export function getInputs(): Inputs {
@@ -55,7 +55,7 @@ class ActionInputs implements Inputs {
   prTitleTemplate: string;
   prMessageTemplate: string;
   commitMessageTemplate: string;
-  ignoreFailureAfterUpdate: boolean;
+  ignoreUpdateFailure: boolean;
 
   constructor() {
     this.repoToken = core.getInput('repo-token', {required: false});
@@ -146,9 +146,8 @@ class ActionInputs implements Inputs {
         'Update Gradle Wrapper from %sourceVersion% to %targetVersion%';
     }
 
-    this.ignoreFailureAfterUpdate = core.getBooleanInput(
-      'ignore-failure-after-update',
-      {required: false}
-    );
+    this.ignoreUpdateFailure = core.getBooleanInput('ignore-update-failure', {
+      required: false
+    });
   }
 }

--- a/src/tasks/main.ts
+++ b/src/tasks/main.ts
@@ -154,7 +154,7 @@ export class MainAction {
           try {
             await updater.update();
           } catch (ex) {
-            if (this.inputs.ignoreFailureAfterUpdate) {
+            if (this.inputs.ignoreUpdateFailure) {
               buildBrokenAfterBump = true;
               core.warning(ex instanceof Error ? ex : `${ex}`);
               core.warning('Ignoring failure after 2nd update');
@@ -171,7 +171,7 @@ export class MainAction {
           try {
             await updater.verify();
           } catch (ex) {
-            if (this.inputs.ignoreFailureAfterUpdate) {
+            if (this.inputs.ignoreUpdateFailure) {
               core.warning(ex instanceof Error ? ex : `${ex}`);
             } else {
               throw ex;

--- a/src/tasks/main.ts
+++ b/src/tasks/main.ts
@@ -168,15 +168,7 @@ export class MainAction {
           core.endGroup();
 
           core.startGroup('Verifying Wrapper');
-          try {
-            await updater.verify();
-          } catch (ex) {
-            if (this.inputs.ignoreUpdateFailure) {
-              core.warning(ex instanceof Error ? ex : `${ex}`);
-            } else {
-              throw ex;
-            }
-          }
+          await updater.verify();
           core.endGroup();
 
           core.startGroup('Committing');

--- a/tests/github/gh-ops.test.ts
+++ b/tests/github/gh-ops.test.ts
@@ -36,7 +36,8 @@ const defaultMockInputs: Inputs = {
     'Update Gradle Wrapper from %sourceVersion% to %targetVersion%',
   prMessageTemplate: '',
   commitMessageTemplate:
-    'Update Gradle Wrapper from %sourceVersion% to %targetVersion%'
+    'Update Gradle Wrapper from %sourceVersion% to %targetVersion%',
+  ignoreFailureAfterUpdate: true
 };
 
 const defaultMockGitHubApi: IGitHubApi = {
@@ -115,6 +116,7 @@ describe('createPullRequest', () => {
         branchName,
         distributionTypes,
         targetRelease,
+        false,
         sourceVersion
       );
 
@@ -137,6 +139,7 @@ describe('createPullRequest', () => {
         branchName,
         distributionTypes,
         targetRelease,
+        false,
         sourceVersion
       );
 
@@ -158,6 +161,7 @@ describe('createPullRequest', () => {
         branchName,
         distributionTypes,
         targetRelease,
+        false,
         sourceVersion
       );
 
@@ -176,6 +180,7 @@ describe('createPullRequest', () => {
         branchName,
         distributionTypes,
         targetRelease,
+        false,
         sourceVersion
       );
 
@@ -216,6 +221,7 @@ describe('createPullRequest', () => {
         branchName,
         distributionTypes,
         targetRelease,
+        false,
         sourceVersion
       );
 
@@ -256,6 +262,7 @@ describe('createPullRequest', () => {
         branchName,
         distributionTypes,
         targetRelease,
+        false,
         sourceVersion
       );
 
@@ -299,6 +306,7 @@ describe('createPullRequest', () => {
         branchName,
         distributionTypes,
         targetRelease,
+        false,
         sourceVersion
       );
 
@@ -342,6 +350,7 @@ describe('createPullRequest', () => {
         branchName,
         distributionTypes,
         targetRelease,
+        false,
         sourceVersion
       );
 
@@ -389,6 +398,7 @@ describe('createPullRequest', () => {
           branchName,
           distributionTypes,
           targetRelease,
+          false,
           sourceVersion
         )
       ).rejects.toThrow('fetch repo error');
@@ -406,6 +416,7 @@ describe('createPullRequest', () => {
           branchName,
           distributionTypes,
           targetRelease,
+          false,
           sourceVersion
         )
       ).rejects.toThrow('create pull request error');

--- a/tests/github/gh-ops.test.ts
+++ b/tests/github/gh-ops.test.ts
@@ -37,7 +37,7 @@ const defaultMockInputs: Inputs = {
   prMessageTemplate: '',
   commitMessageTemplate:
     'Update Gradle Wrapper from %sourceVersion% to %targetVersion%',
-  ignoreFailureAfterUpdate: true
+  ignoreUpdateFailure: true
 };
 
 const defaultMockGitHubApi: IGitHubApi = {

--- a/tests/inputs/inputs.test.ts
+++ b/tests/inputs/inputs.test.ts
@@ -26,7 +26,7 @@ describe('getInputs', () => {
       return ymlInputs[name] || '';
     });
     jest.spyOn(core, 'getBooleanInput').mockImplementation((name: string) => {
-      return name == 'ignore-failure-after-update';
+      return name == 'ignore-update-failure';
     });
   });
 
@@ -50,7 +50,7 @@ describe('getInputs', () => {
         "baseBranch": "",
         "commitMessageTemplate": "Update Gradle Wrapper from %sourceVersion% to %targetVersion%",
         "distributionsBaseUrl": "",
-        "ignoreFailureAfterUpdate": true,
+        "ignoreUpdateFailure": true,
         "labels": [],
         "mergeMethod": undefined,
         "paths": [],

--- a/tests/inputs/inputs.test.ts
+++ b/tests/inputs/inputs.test.ts
@@ -25,6 +25,9 @@ describe('getInputs', () => {
     jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
       return ymlInputs[name] || '';
     });
+    jest.spyOn(core, 'getBooleanInput').mockImplementation((name: string) => {
+      return name == 'ignore-failure-after-update';
+    });
   });
 
   beforeEach(() => {
@@ -47,6 +50,7 @@ describe('getInputs', () => {
         "baseBranch": "",
         "commitMessageTemplate": "Update Gradle Wrapper from %sourceVersion% to %targetVersion%",
         "distributionsBaseUrl": "",
+        "ignoreFailureAfterUpdate": true,
         "labels": [],
         "mergeMethod": undefined,
         "paths": [],

--- a/tests/tasks/main.test.ts
+++ b/tests/tasks/main.test.ts
@@ -49,7 +49,7 @@ const defaultMockInputs: Inputs = {
   prMessageTemplate: '',
   commitMessageTemplate:
     'Update Gradle Wrapper from %sourceVersion% to %targetVersion%',
-  ignoreFailureAfterUpdate: true
+  ignoreUpdateFailure: true
 };
 
 const defaultMockGitHubApi: IGitHubApi = {


### PR DESCRIPTION
Minor behavior change on the `Updating Wrapper (2nd update)` step to allow the bump PR to be created even if the bump has broken the build.

This will allow the maintainers to address the breaking changes without doing the bump themselves.

I discovered this issue on the [recent `Gradle 8.13` breaking change](https://github.com/gmazzo/gradle-module-kind-plugin/actions/runs/13712036972/job/38350231168#step:4:91):
The failure went unnoticed, and no PR was opened, defeating the purpose of the action.

After [this change](https://github.com/gmazzo/gradle-module-kind-plugin/actions/runs/13722723366/job/38381741586#step:4:142), I got the [PR anyway](https://github.com/gmazzo/gradle-module-kind-plugin/pull/14), broken obviously. 

![image](https://github.com/user-attachments/assets/c2fcc5f3-2fc5-4083-992a-99e0abb076d0)

A warning will also be appended to the end of the PR when this condition is met:
![image](https://github.com/user-attachments/assets/2eaabcab-e8d7-466a-87f3-5594b4d277a5)

IMHO this new behavior is more close to Dependabot's one.

Introduces an `ignore-failure-after-update` as an opt-out flag
