### PR TITLE
Update GitHub Actions checkout action version

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
[checkout action](https://github.com/actions/checkout) is now v5 - to enable easy copy and paste from the README.md, this PR updates the version.