### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v5.0.0
         with:
           node-version: 20


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions CI workflow configuration. The main change is tightening permissions and improving security for the workflow.

- Security improvements:
  * [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR10-R19): Explicitly sets `permissions: {}` to restrict default permissions for the workflow, and disables credential persistence during the `actions/checkout` step by setting `persist-credentials: false`.