### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/usage-count.yml
+++ b/.github/workflows/usage-count.yml
@@ -3,6 +3,8 @@ name: Usage Count
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
 jobs:
   usage-count:
     runs-on: ubuntu-latest

--- a/.github/workflows/usage-count.yml
+++ b/.github/workflows/usage-count.yml
@@ -3,8 +3,8 @@ name: Usage Count
 on:
   workflow_dispatch
 
-permissions:
-  contents: read
+permissions: {}
+
 jobs:
   usage-count:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gradle-update/update-gradle-wrapper-action/security/code-scanning/8](https://github.com/gradle-update/update-gradle-wrapper-action/security/code-scanning/8)

To fix this issue, add a `permissions` block to the workflow so that the job only gets the minimal set of privileges required. In this case, the workflow only seems to use the REST API for searching code (read-only operation) and does not require any write access. Therefore, we should set `permissions: contents: read` at the workflow or job level, restricting the GITHUB_TOKEN so it cannot make changes. This change should be added to the root level of the workflow file (preferably before `jobs:`) or under the specific job, but root level is simpler and applies to all jobs by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
