### PR TITLE
Update README with GitHub Actions permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest
@@ -71,6 +75,11 @@ jobs:
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v2
 ```
+
+Ensure that you allow GitHub Actions to create and approve pull requests. To do
+this, navigate to "Settings", select "Actions" on the left. Select "General".
+Scroll down to the very end. Find "Allow GitHub Actions to create and approve
+pull requests". Enable it. Click on "Save".
 
 The action will run every day around midnight, check if a new Gradle version is
 available and create a Pull Request to update the Gradle Wrapper script.


### PR DESCRIPTION
I refined the starting example based on the most recent security things.

If one misses `contents: write`, one gets

    ❌ Resource not accessible by integration - https://docs.github.com/rest/pulls/pulls#create-a-pull-request

(https://github.com/koppor/openj9-hash-issue/actions/runs/18925607175)

If one misses "pull-request: write", one gets

    Error: ❌ Validation Failed: {"resource":"PullRequest","field":"head","code":"invalid"} - https://docs.github.com/rest/pulls/pulls#create-a-pull-request

(https://github.com/koppor/openj9-hash-issue/actions/runs/18950395801/job/54113217034)

If one misses to change the settings in the repository, one gets

    ❌ GitHub Actions is not permitted to create or approve pull requests. - https://docs.github.com/rest/pulls/pulls#create-a-pull-request


With this update, it should be easy for users to copy and paste the basic configuration without having the need to create and maintain a separate token.

---

<img width="1229" height="1086" alt="grafik" src="https://github.com/user-attachments/assets/40850f10-24a6-40d9-9742-b3a5bffd1980" />
