### PR TITLE
Update README to support `actions/checkout@v6`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
Updating the README to reflect [fix](https://github.com/gradle-update/update-gradle-wrapper-action/issues/988#issuecomment-3707440717) to support Github actions/checkout@v6 given their recent breaking changes.