### PR TITLE
Set Dependabot cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,13 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    cooldown:
+      default-days: 3
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
   - package-ecosystem: 'github-actions'
     directory: '/'
+    cooldown:
+      default-days: 3
     schedule:
-      interval: 'daily'
+      interval: 'weekly'


### PR DESCRIPTION
Change the update schedule for npm and GitHub Actions from daily to weekly, and add a cooldown period of 3 days.