### PR TITLE
Migrate tests to ESM

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,23 +4,19 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.ts'],
   coverageReporters: ['json'],
   errorOnDeprecated: true,
+  extensionsToTreatAsEsm: ['.ts'],
   moduleFileExtensions: ['js', 'ts'],
-  restoreMocks: true,
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
   transform: {
     '^.+\\.ts$': [
       'ts-jest',
       {
-        isolatedModules: true,
-        tsconfig: {module: 'commonjs', moduleResolution: 'node'}
+        useESM: true
       }
     ]
   },
   moduleNameMapper: {
-    // @actions/exec v3 is ESM-only; tests always mock at the cmd boundary,
-    // so swap it for a tiny CJS stub to keep Jest running as CJS.
-    '^@actions/exec$': '<rootDir>/tests/mocks/actions-exec.cjs',
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   verbose: true

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint-check": "eslint .",
     "build": "tsc",
     "pack": "ncc build",
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "all": "npm ls && npm run clean && npm run format && npm run lint && npm run build && npm run test && npm run pack"
   },
   "author": "Cristian Greco",

--- a/tests/git/git-auth.test.ts
+++ b/tests/git/git-auth.test.ts
@@ -12,22 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as core from '@actions/core';
+import {jest} from '@jest/globals';
 
-import * as auth from '../../src/git/git-auth';
-import * as git from '../../src/git/git-cmds';
+import {coreMock} from '../mocks/core';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+
+jest.unstable_mockModule('../../src/git/git-cmds', () => ({
+  config: jest.fn(),
+  unsetConfig: jest.fn(),
+  fetch: jest.fn(),
+  checkout: jest.fn(),
+  checkoutCreateBranch: jest.fn(),
+  add: jest.fn(),
+  commit: jest.fn(),
+  push: jest.fn(),
+  parseHead: jest.fn(),
+  gitDiffNameOnly: jest.fn()
+}));
+
+const core = await import('@actions/core');
+const auth = await import('../../src/git/git-auth');
+const git = await import('../../src/git/git-cmds');
 
 describe('setup', () => {
   it('sets git extraheader configuration', async () => {
     const mockInputs = Object.create({repoToken: 's3cr3t'});
-    const setSecret = jest.spyOn(core, 'setSecret').mockImplementation();
-    const gitConfig = jest.spyOn(git, 'config').mockImplementation();
 
     await auth.setup(mockInputs);
 
-    expect(setSecret).toHaveBeenCalledWith('eC1hY2Nlc3MtdG9rZW46czNjcjN0');
+    expect(core.setSecret).toHaveBeenCalledWith('eC1hY2Nlc3MtdG9rZW46czNjcjN0');
 
-    expect(gitConfig).toHaveBeenCalledWith(
+    expect(git.config).toHaveBeenCalledWith(
       'http.https://github.com/.extraheader',
       'Authorization: basic eC1hY2Nlc3MtdG9rZW46czNjcjN0'
     );
@@ -36,11 +52,9 @@ describe('setup', () => {
 
 describe('cleanup', () => {
   it('unsets git extraheader configuration', async () => {
-    const gitUnsetConfig = jest.spyOn(git, 'unsetConfig').mockImplementation();
-
     await auth.cleanup();
 
-    expect(gitUnsetConfig).toHaveBeenCalledWith(
+    expect(git.unsetConfig).toHaveBeenCalledWith(
       'http.https://github.com/.extraheader'
     );
   });

--- a/tests/git/git-cmds.test.ts
+++ b/tests/git/git-cmds.test.ts
@@ -12,13 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as cmd from '../../src/cmd';
-import * as git from '../../src/git/git-cmds';
+import {jest} from '@jest/globals';
+
+import {coreMock} from '../mocks/core';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+
+jest.unstable_mockModule('../../src/cmd', () => ({
+  execWithOutput: jest.fn()
+}));
+
+const cmd = await import('../../src/cmd');
+const git = await import('../../src/git/git-cmds');
 
 describe('gitDiffNameOnly', () => {
   describe('when no files has been modified', () => {
     it('execs "git diff" and returns empty array', async () => {
-      const exec = jest.spyOn(cmd, 'execWithOutput').mockResolvedValue({
+      jest.mocked(cmd.execWithOutput).mockResolvedValue({
         exitCode: 0,
         stdout: '',
         stderr: ''
@@ -26,7 +36,10 @@ describe('gitDiffNameOnly', () => {
 
       const files = await git.gitDiffNameOnly();
 
-      expect(exec).toHaveBeenCalledWith('git', ['diff', '--name-only']);
+      expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
+        'diff',
+        '--name-only'
+      ]);
 
       expect(files).toEqual([]);
     });
@@ -34,7 +47,7 @@ describe('gitDiffNameOnly', () => {
 
   describe('when some files have been modified', () => {
     it('execs "git diff" and returns the file names', async () => {
-      const exec = jest.spyOn(cmd, 'execWithOutput').mockResolvedValue({
+      jest.mocked(cmd.execWithOutput).mockResolvedValue({
         exitCode: 0,
         stdout: 'path/to/file.txt\ncode.js\n',
         stderr: ''
@@ -42,7 +55,10 @@ describe('gitDiffNameOnly', () => {
 
       const files = await git.gitDiffNameOnly();
 
-      expect(exec).toHaveBeenCalledWith('git', ['diff', '--name-only']);
+      expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
+        'diff',
+        '--name-only'
+      ]);
 
       expect(files).toEqual(['path/to/file.txt', 'code.js']);
     });
@@ -51,47 +67,52 @@ describe('gitDiffNameOnly', () => {
 
 describe('parseHead', () => {
   it('execs "git rev-parse" for current HEAD', async () => {
-    const exec = jest
-      .spyOn(cmd, 'execWithOutput')
+    jest
+      .mocked(cmd.execWithOutput)
       .mockResolvedValue({exitCode: 0, stdout: 'abc123', stderr: ''});
 
     const headSha = await git.parseHead();
 
-    expect(exec).toHaveBeenCalledWith('git', ['rev-parse', 'HEAD']);
+    expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
+      'rev-parse',
+      'HEAD'
+    ]);
     expect(headSha).toEqual('abc123');
   });
 });
 
 describe('fetch', () => {
   it('execs "git fetch" with with depth option', async () => {
-    const exec = jest.spyOn(cmd, 'execWithOutput').mockImplementation();
-
     await git.fetch();
 
-    expect(exec).toHaveBeenCalledWith('git', ['fetch', '--depth=1']);
+    expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
+      'fetch',
+      '--depth=1'
+    ]);
   });
 });
 
 describe('checkout', () => {
   it('execs "git checkout" with the given branch name and returns exit code', async () => {
-    const exec = jest
-      .spyOn(cmd, 'execWithOutput')
+    jest
+      .mocked(cmd.execWithOutput)
       .mockResolvedValue({exitCode: 0, stdout: '', stderr: ''});
 
     const exitCode = await git.checkout('main-branch');
 
-    expect(exec).toHaveBeenCalledWith('git', ['checkout', 'main-branch']);
+    expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
+      'checkout',
+      'main-branch'
+    ]);
     expect(exitCode).toEqual(0);
   });
 });
 
 describe('checkoutCreateBranch', () => {
   it('execs "git checkout -b" with the given branch name and start point', async () => {
-    const exec = jest.spyOn(cmd, 'execWithOutput').mockImplementation();
-
     await git.checkoutCreateBranch('main-branch', 'head-ref');
 
-    expect(exec).toHaveBeenCalledWith('git', [
+    expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
       'checkout',
       '-b',
       'main-branch',
@@ -102,11 +123,9 @@ describe('checkoutCreateBranch', () => {
 
 describe('add', () => {
   it('execs "git add" with the given paths', async () => {
-    const exec = jest.spyOn(cmd, 'execWithOutput').mockImplementation();
-
     await git.add(['path/to/file.txt', '../folder/another/data.csv']);
 
-    expect(exec).toHaveBeenCalledWith('git', [
+    expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
       'add',
       'path/to/file.txt',
       '../folder/another/data.csv'
@@ -116,11 +135,9 @@ describe('add', () => {
 
 describe('commit', () => {
   it('execs "git commit" with the given message body', async () => {
-    const exec = jest.spyOn(cmd, 'execWithOutput').mockImplementation();
-
     await git.commit('this is a commit message');
 
-    expect(exec).toHaveBeenCalledWith('git', [
+    expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
       'commit',
       '-m',
       'this is a commit message',
@@ -131,11 +148,9 @@ describe('commit', () => {
 
 describe('config', () => {
   it('execs "git config" to set local configuration for key and value', async () => {
-    const exec = jest.spyOn(cmd, 'execWithOutput').mockImplementation();
-
     await git.config('key', 'value');
 
-    expect(exec).toHaveBeenCalledWith('git', [
+    expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
       'config',
       '--local',
       'key',
@@ -146,11 +161,9 @@ describe('config', () => {
 
 describe('unsetConfig', () => {
   it('execs "git config" to unset local configuration for key', async () => {
-    const exec = jest.spyOn(cmd, 'execWithOutput').mockImplementation();
-
     await git.unsetConfig('key');
 
-    expect(exec).toHaveBeenCalledWith('git', [
+    expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
       'config',
       '--local',
       '--unset-all',
@@ -161,11 +174,9 @@ describe('unsetConfig', () => {
 
 describe('push', () => {
   it('execs "git push" to origin and head of the specified branch', async () => {
-    const exec = jest.spyOn(cmd, 'execWithOutput').mockImplementation();
-
     await git.push('my-feature-branch');
 
-    expect(exec).toHaveBeenCalledWith('git', [
+    expect(cmd.execWithOutput).toHaveBeenCalledWith('git', [
       'push',
       '--force-with-lease',
       'origin',

--- a/tests/github/gh-api.test.ts
+++ b/tests/github/gh-api.test.ts
@@ -12,12 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as github from '@actions/github';
-import * as core from '@actions/core';
-import * as store from '../../src/store';
+import {jest} from '@jest/globals';
 
-import {GitHubApi} from '../../src/github/gh-api';
 import {RequestError} from '@octokit/request-error';
+
+import {coreMock} from '../mocks/core';
+import {githubMock} from '../mocks/github';
+import {storeMock} from '../mocks/store';
+
+import type {GitHubApi} from '../../src/github/gh-api';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+jest.unstable_mockModule('@actions/github', githubMock);
+jest.unstable_mockModule('../../src/store', storeMock);
+
+const github = await import('@actions/github');
+const core = await import('@actions/core');
+const store = await import('../../src/store');
+const {GitHubApi} = await import('../../src/github/gh-api');
 
 let api: GitHubApi;
 let mockOctokit: any;
@@ -42,16 +54,9 @@ beforeEach(() => {
     graphql: jest.fn()
   };
 
-  jest.spyOn(github, 'getOctokit').mockReturnValue(mockOctokit);
+  jest.mocked(github.getOctokit).mockReturnValue(mockOctokit);
 
   api = new GitHubApi('s3cr3t');
-
-  jest.spyOn(github.context, 'repo', 'get').mockImplementation(() => {
-    return {
-      owner: 'owner-name',
-      repo: 'repo-name'
-    };
-  });
 });
 
 describe('repoDefaultBranch', () => {
@@ -136,10 +141,6 @@ describe('createPullRequest', () => {
 });
 
 describe('addReviewers', () => {
-  beforeEach(() => {
-    jest.spyOn(store, 'setErroredReviewers');
-  });
-
   it('does nothing when `reviewers` is empty', async () => {
     await api.addReviewers(1, []);
 
@@ -295,10 +296,6 @@ describe('addReviewer', () => {
 });
 
 describe('addTeamReviewers', () => {
-  beforeEach(() => {
-    jest.spyOn(store, 'setErroredTeamReviewers');
-  });
-
   it('does nothing when `teams` is empty', async () => {
     await api.addTeamReviewers(1, []);
 
@@ -679,11 +676,9 @@ describe('enableAutoMerge', () => {
   });
 
   it('logs error for invalid merge method', async () => {
-    const coreSpy = jest.spyOn(core, 'error');
-
     await api.enableAutoMerge(42, 'INVALID');
 
-    expect(coreSpy).toHaveBeenCalledWith(
+    expect(core.error).toHaveBeenCalledWith(
       expect.stringContaining('merge-method must be one of the following')
     );
   });

--- a/tests/github/gh-ops.test.ts
+++ b/tests/github/gh-ops.test.ts
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as github from '@actions/github';
+import {jest} from '@jest/globals';
 
-import {GitHubOps} from '../../src/github/gh-ops';
-import {IGitHubApi} from '../../src/github/gh-api';
-import {Inputs} from '../../src/inputs/';
-import {Release} from '../../src/releases';
+import {coreMock} from '../mocks/core';
+import {githubMock} from '../mocks/github';
+
+import type {Inputs} from '../../src/inputs';
+import type {IGitHubApi} from '../../src/github/gh-api';
+import type {Release} from '../../src/releases';
+import type {GitHubOps} from '../../src/github/gh-ops';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+jest.unstable_mockModule('@actions/github', githubMock);
+
+const github = await import('@actions/github');
+const {GitHubOps} = await import('../../src/github/gh-ops');
 
 const defaultMockInputs: Inputs = {
   repoToken: 's3cr3t',
@@ -68,16 +77,9 @@ beforeEach(() => {
     }
   };
 
-  jest.spyOn(github, 'getOctokit').mockReturnValue(mockOctokit);
+  jest.mocked(github.getOctokit).mockReturnValue(mockOctokit);
 
   githubOps = new GitHubOps(mockInputs, mockGitHubApi);
-
-  jest.spyOn(github.context, 'repo', 'get').mockImplementation(() => {
-    return {
-      owner: 'owner-name',
-      repo: 'repo-name'
-    };
-  });
 });
 
 describe('createPullRequest', () => {

--- a/tests/inputs/inputs.test.ts
+++ b/tests/inputs/inputs.test.ts
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as core from '@actions/core';
+import {jest} from '@jest/globals';
 
-import {getInputs} from '../../src/inputs';
+import {coreMock} from '../mocks/core';
 
-jest.mock('@actions/core');
+jest.unstable_mockModule('@actions/core', coreMock);
+
+const core = await import('@actions/core');
+const {getInputs} = await import('../../src/inputs');
 
 describe('getInputs', () => {
   let ymlInputs = {} as {[key: string]: string};
 
   beforeAll(() => {
-    jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
+    jest.mocked(core.getInput).mockImplementation((name: string) => {
       return ymlInputs[name] || '';
     });
   });

--- a/tests/mocks/actions-exec.cjs
+++ b/tests/mocks/actions-exec.cjs
@@ -1,8 +1,0 @@
-module.exports = {
-  getExecOutput: async () => ({
-    exitCode: 0,
-    stdout: '',
-    stderr: ''
-  }),
-  exec: async () => 0
-};

--- a/tests/mocks/core.ts
+++ b/tests/mocks/core.ts
@@ -1,0 +1,15 @@
+import {jest} from '@jest/globals';
+
+export const coreMock = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  setFailed: jest.fn(),
+  startGroup: jest.fn(),
+  endGroup: jest.fn(),
+  setSecret: jest.fn(),
+  saveState: jest.fn(),
+  getState: jest.fn(),
+  getInput: jest.fn()
+});

--- a/tests/mocks/github.ts
+++ b/tests/mocks/github.ts
@@ -1,0 +1,8 @@
+import {jest} from '@jest/globals';
+
+export const githubMock = () => ({
+  getOctokit: jest.fn(),
+  context: {
+    repo: {owner: 'owner-name', repo: 'repo-name'}
+  }
+});

--- a/tests/mocks/store.ts
+++ b/tests/mocks/store.ts
@@ -1,0 +1,12 @@
+import {jest} from '@jest/globals';
+
+export const storeMock = () => ({
+  setMainActionExecuted: jest.fn(),
+  mainActionExecuted: jest.fn(),
+  setPullRequestData: jest.fn(),
+  getPullRequestData: jest.fn(),
+  setErroredReviewers: jest.fn(),
+  getErroredReviewers: jest.fn(),
+  setErroredTeamReviewers: jest.fn(),
+  getErroredTeamReviewers: jest.fn()
+});

--- a/tests/releases.test.ts
+++ b/tests/releases.test.ts
@@ -12,9 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import nock from 'nock';
+import {jest} from '@jest/globals';
 
-import {Releases} from '../src/releases';
+import nock from 'nock';
+import * as path from 'path';
+import {fileURLToPath} from 'url';
+
+import {coreMock} from './mocks/core';
+
+import type {Releases} from '../src/releases';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+
+const {Releases} = await import('../src/releases');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 let releases: Releases;
 

--- a/tests/store/store.test.ts
+++ b/tests/store/store.test.ts
@@ -12,47 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as core from '@actions/core';
+import {jest} from '@jest/globals';
 
-import * as store from '../../src/store';
+import {coreMock} from '../mocks/core';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+
+const core = await import('@actions/core');
+const store = await import('../../src/store');
 
 describe('setMainActionExecuted', () => {
   it('saves a state variable as "true"', () => {
-    const saveState = jest.spyOn(core, 'saveState');
-
     store.setMainActionExecuted();
 
-    expect(saveState).toHaveBeenCalledWith('main_action_executed', 'true');
+    expect(core.saveState).toHaveBeenCalledWith('main_action_executed', 'true');
   });
 });
 
 describe('mainActionExecuted', () => {
   it('returns true if the state variable is set to string "true"', () => {
-    const saveState = jest.spyOn(core, 'getState').mockReturnValue('true');
+    jest.mocked(core.getState).mockReturnValue('true');
 
     const executed = store.mainActionExecuted();
 
-    expect(saveState).toHaveBeenCalledWith('main_action_executed');
+    expect(core.getState).toHaveBeenCalledWith('main_action_executed');
     expect(executed).toBeTruthy();
   });
 
   it('returns false if the state variable is not set to string "true', () => {
-    const saveState = jest.spyOn(core, 'getState').mockReturnValue('');
+    jest.mocked(core.getState).mockReturnValue('');
 
     const executed = store.mainActionExecuted();
 
-    expect(saveState).toHaveBeenCalledWith('main_action_executed');
+    expect(core.getState).toHaveBeenCalledWith('main_action_executed');
     expect(executed).toBeFalsy();
   });
 });
 
 describe('setPullRequestData', () => {
   it('saves a state variable as json representation of input data', () => {
-    const saveState = jest.spyOn(core, 'saveState');
-
     store.setPullRequestData({url: 'https://github.com/pull/42', number: 42});
 
-    expect(saveState).toHaveBeenCalledWith(
+    expect(core.saveState).toHaveBeenCalledWith(
       'pull_request_data',
       '{"url":"https://github.com/pull/42","number":42}'
     );
@@ -61,22 +62,22 @@ describe('setPullRequestData', () => {
 
 describe('getPullRequestData', () => {
   it('returns undefined if the state variable is empty', () => {
-    const getState = jest.spyOn(core, 'getState').mockReturnValue('');
+    jest.mocked(core.getState).mockReturnValue('');
 
     const pullRequestData = store.getPullRequestData();
 
-    expect(getState).toHaveBeenCalledWith('pull_request_data');
+    expect(core.getState).toHaveBeenCalledWith('pull_request_data');
     expect(pullRequestData).toBeUndefined();
   });
 
   it('returns data if the state variable is set to valid json', () => {
-    const getState = jest
-      .spyOn(core, 'getState')
+    jest
+      .mocked(core.getState)
       .mockReturnValue('{"url":"https://github.com/pull/42","number":42}');
 
     const isCompleted = store.getPullRequestData();
 
-    expect(getState).toHaveBeenCalledWith('pull_request_data');
+    expect(core.getState).toHaveBeenCalledWith('pull_request_data');
     expect(isCompleted).toEqual({
       url: 'https://github.com/pull/42',
       number: 42
@@ -86,51 +87,48 @@ describe('getPullRequestData', () => {
 
 describe('setErroredReviewers', () => {
   it('saves a state variable as json representation of input array', () => {
-    const saveState = jest.spyOn(core, 'saveState');
-
     store.setErroredReviewers(['a', 'b']);
 
-    expect(saveState).toHaveBeenCalledWith('errored_reviewers', '["a","b"]');
+    expect(core.saveState).toHaveBeenCalledWith(
+      'errored_reviewers',
+      '["a","b"]'
+    );
   });
 
   describe('when input is empty', () => {
     it('saves a state variable as json empty array', () => {
-      const saveState = jest.spyOn(core, 'saveState');
-
       store.setErroredReviewers([]);
 
-      expect(saveState).toHaveBeenCalledWith('errored_reviewers', '[]');
+      expect(core.saveState).toHaveBeenCalledWith('errored_reviewers', '[]');
     });
   });
 });
 
 describe('getErroredReviewers', () => {
   it('returns undefined if the state variable is empty', () => {
-    const getState = jest.spyOn(core, 'getState').mockReturnValue('');
+    jest.mocked(core.getState).mockReturnValue('');
 
     const pullRequestData = store.getErroredReviewers();
 
-    expect(getState).toHaveBeenCalledWith('errored_reviewers');
+    expect(core.getState).toHaveBeenCalledWith('errored_reviewers');
     expect(pullRequestData).toBeUndefined();
   });
 
   it('returns an array of strings if the state variable is set to valid json', () => {
-    const getState = jest.spyOn(core, 'getState').mockReturnValue('["a"]');
+    jest.mocked(core.getState).mockReturnValue('["a"]');
 
     const reviewers = store.getErroredReviewers();
 
     expect(reviewers).toEqual(['a']);
-    expect(getState).toHaveBeenCalledWith('errored_reviewers');
+    expect(core.getState).toHaveBeenCalledWith('errored_reviewers');
   });
 });
 
 describe('setErroredTeamReviewers', () => {
   it('saves a state variable as json representation of input array', () => {
-    const saveState = jest.spyOn(core, 'saveState');
-
     store.setErroredTeamReviewers(['a', 'b']);
 
-    expect(saveState).toHaveBeenCalledWith(
+    expect(core.saveState).toHaveBeenCalledWith(
       'errored_team_reviewers',
       '["a","b"]'
     );
@@ -138,31 +136,32 @@ describe('setErroredTeamReviewers', () => {
 
   describe('when input is empty', () => {
     it('saves a state variable as json empty array', () => {
-      const saveState = jest.spyOn(core, 'saveState');
-
       store.setErroredTeamReviewers([]);
 
-      expect(saveState).toHaveBeenCalledWith('errored_team_reviewers', '[]');
+      expect(core.saveState).toHaveBeenCalledWith(
+        'errored_team_reviewers',
+        '[]'
+      );
     });
   });
 });
 
 describe('getErroredTeamReviewers', () => {
   it('returns undefined if the state variable is empty', () => {
-    const getState = jest.spyOn(core, 'getState').mockReturnValue('');
+    jest.mocked(core.getState).mockReturnValue('');
 
     const pullRequestData = store.getErroredTeamReviewers();
 
-    expect(getState).toHaveBeenCalledWith('errored_team_reviewers');
+    expect(core.getState).toHaveBeenCalledWith('errored_team_reviewers');
     expect(pullRequestData).toBeUndefined();
   });
 
   it('returns an array of strings if the state variable is set to valid json', () => {
-    const getState = jest.spyOn(core, 'getState').mockReturnValue('["a"]');
+    jest.mocked(core.getState).mockReturnValue('["a"]');
 
     const reviewers = store.getErroredTeamReviewers();
 
     expect(reviewers).toEqual(['a']);
-    expect(getState).toHaveBeenCalledWith('errored_team_reviewers');
+    expect(core.getState).toHaveBeenCalledWith('errored_team_reviewers');
   });
 });

--- a/tests/tasks/main.test.ts
+++ b/tests/tasks/main.test.ts
@@ -12,19 +12,65 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as commit from '../../src/git/git-commit';
-import * as git from '../../src/git/git-cmds';
-import * as gitAuth from '../../src/git/git-auth';
-import * as store from '../../src/store';
-import * as wrapper from '../../src/wrapperInfo';
-import * as wrapperFind from '../../src/wrapper/find';
-import * as wrapperUpdater from '../../src/wrapperUpdater';
+import {jest} from '@jest/globals';
 
-import {GitHubOps} from '../../src/github/gh-ops';
-import {IGitHubApi} from '../../src/github/gh-api';
-import {Inputs} from '../../src/inputs/';
-import {MainAction} from '../../src/tasks/main';
-import {Release, Releases} from '../../src/releases';
+import {coreMock} from '../mocks/core';
+import {storeMock} from '../mocks/store';
+
+import type {IGitHubApi} from '../../src/github/gh-api';
+import type {GitHubOps} from '../../src/github/gh-ops';
+import type {Inputs} from '../../src/inputs';
+import type {Release, Releases} from '../../src/releases';
+import type {MainAction} from '../../src/tasks/main';
+import type {IWrapperInfo} from '../../src/wrapperInfo';
+import type {IWrapperUpdater} from '../../src/wrapperUpdater';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+
+jest.unstable_mockModule('../../src/git/git-commit', () => ({
+  commit: jest.fn()
+}));
+
+jest.unstable_mockModule('../../src/git/git-cmds', () => ({
+  config: jest.fn(),
+  unsetConfig: jest.fn(),
+  fetch: jest.fn(),
+  checkout: jest.fn(),
+  checkoutCreateBranch: jest.fn(),
+  add: jest.fn(),
+  commit: jest.fn(),
+  push: jest.fn(),
+  parseHead: jest.fn(),
+  gitDiffNameOnly: jest.fn()
+}));
+
+jest.unstable_mockModule('../../src/git/git-auth', () => ({
+  setup: jest.fn(),
+  cleanup: jest.fn()
+}));
+
+jest.unstable_mockModule('../../src/store', storeMock);
+
+jest.unstable_mockModule('../../src/wrapperInfo', () => ({
+  createWrapperInfo: jest.fn()
+}));
+
+jest.unstable_mockModule('../../src/wrapper/find', () => ({
+  findWrapperPropertiesFiles: jest.fn()
+}));
+
+jest.unstable_mockModule('../../src/wrapperUpdater', () => ({
+  createWrapperUpdater: jest.fn()
+}));
+
+const commit = await import('../../src/git/git-commit');
+const git = await import('../../src/git/git-cmds');
+const store = await import('../../src/store');
+const wrapper = await import('../../src/wrapperInfo');
+const wrapperFind = await import('../../src/wrapper/find');
+const wrapperUpdater = await import('../../src/wrapperUpdater');
+
+const {MainAction} = await import('../../src/tasks/main');
 
 let mainAction: MainAction;
 let mockInputs: Inputs;
@@ -84,61 +130,55 @@ beforeEach(() => {
 
 describe('run', () => {
   it('creates a Pull Request to update wrapper files', async () => {
-    jest.spyOn(store, 'setMainActionExecuted').mockImplementation();
+    mockReleases.fetchReleaseInformation = jest
+      .fn<() => Promise<Release>>()
+      .mockResolvedValue({
+        version: '1.0.1',
+        allChecksum: 'dist-all-checksum-value',
+        binChecksum: 'dist-bin-checksum-value',
+        wrapperChecksum: 'wrapper-jar-checksum-value'
+      });
 
-    jest.spyOn(gitAuth, 'setup').mockImplementation();
-
-    mockReleases.fetchReleaseInformation = jest.fn().mockReturnValue({
-      version: '1.0.1',
-      allChecksum: 'dist-all-checksum-value',
-      binChecksum: 'dist-bin-checksum-value',
-      wrapperChecksum: 'wrapper-jar-checksum-value'
-    } as Release);
-
-    mockGitHubOps.findMatchingRef = jest.fn().mockReturnValue(undefined);
+    mockGitHubOps.findMatchingRef = jest
+      .fn<() => Promise<undefined>>()
+      .mockResolvedValue(undefined);
 
     jest
-      .spyOn(wrapperFind, 'findWrapperPropertiesFiles')
+      .mocked(wrapperFind.findWrapperPropertiesFiles)
       .mockResolvedValue(['/path/to/gradle/wrapper/gradle-wrapper.properties']);
 
-    jest.spyOn(wrapper, 'createWrapperInfo').mockReturnValue({
+    jest.mocked(wrapper.createWrapperInfo).mockReturnValue({
       version: '1.0.0',
       path: '/path/to/gradle/wrapper/gradle-wrapper.properties',
       distType: 'bin',
       basePath: '/path/to/gradle'
-    } as wrapper.IWrapperInfo);
+    } as IWrapperInfo);
 
-    jest.spyOn(git, 'config').mockImplementation();
+    mockGitHubApi.repoDefaultBranch = jest
+      .fn<() => Promise<string>>()
+      .mockResolvedValue('master');
 
-    mockGitHubApi.repoDefaultBranch = jest.fn().mockReturnValue('master');
+    jest.mocked(git.checkout).mockResolvedValue(0);
+    jest.mocked(git.parseHead).mockResolvedValue('abc123');
 
-    jest.spyOn(git, 'fetch').mockImplementation();
-    jest.spyOn(git, 'checkout').mockResolvedValue(0);
-    jest.spyOn(git, 'parseHead').mockResolvedValue('abc123');
-    jest.spyOn(git, 'checkoutCreateBranch').mockImplementation();
-
-    jest.spyOn(wrapperUpdater, 'createWrapperUpdater').mockReturnValue({
-      update: jest.fn().mockImplementation(),
-      verify: jest.fn().mockImplementation()
-    } as wrapperUpdater.IWrapperUpdater);
+    jest.mocked(wrapperUpdater.createWrapperUpdater).mockReturnValue({
+      update: jest.fn(),
+      verify: jest.fn()
+    } as unknown as IWrapperUpdater);
 
     jest
-      .spyOn(git, 'gitDiffNameOnly')
+      .mocked(git.gitDiffNameOnly)
       .mockResolvedValue([
         '/path/to/gradle/wrapper/gradle-wrapper.properties',
         '/path/to/gradle/wrapper/gradle-wrapper.jar'
       ]);
 
-    jest.spyOn(commit, 'commit').mockImplementation();
-
-    jest.spyOn(git, 'push').mockImplementation();
-
-    mockGitHubOps.createPullRequest = jest.fn().mockReturnValue({
-      url: 'https://github.com/owner/repo/pulls/42',
-      number: 42
-    } as store.PullRequestData);
-
-    jest.spyOn(store, 'setPullRequestData').mockImplementation();
+    mockGitHubOps.createPullRequest = jest
+      .fn<() => Promise<{url: string; number: number}>>()
+      .mockResolvedValue({
+        url: 'https://github.com/owner/repo/pulls/42',
+        number: 42
+      });
 
     await mainAction.run();
 

--- a/tests/tasks/post.test.ts
+++ b/tests/tasks/post.test.ts
@@ -12,11 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as gitAuth from '../../src/git/git-auth';
-import * as store from '../../src/store';
+import {jest} from '@jest/globals';
 
-import {IGitHubApi} from '../../src/github/gh-api';
-import {PostAction} from '../../src/tasks/post';
+import {coreMock} from '../mocks/core';
+import {storeMock} from '../mocks/store';
+
+import type {IGitHubApi} from '../../src/github/gh-api';
+import type {PostAction} from '../../src/tasks/post';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+
+jest.unstable_mockModule('../../src/git/git-auth', () => ({
+  setup: jest.fn(),
+  cleanup: jest.fn()
+}));
+
+jest.unstable_mockModule('../../src/store', storeMock);
+
+const store = await import('../../src/store');
+const {PostAction} = await import('../../src/tasks/post');
 
 let mockGitHubApi: IGitHubApi;
 let postAction: PostAction;
@@ -36,8 +50,6 @@ const defaultMockGitHubApi: IGitHubApi = {
 beforeEach(() => {
   mockGitHubApi = Object.create(defaultMockGitHubApi);
 
-  jest.spyOn(gitAuth, 'cleanup').mockImplementation();
-
   postAction = new PostAction(mockGitHubApi, {
     url: 'https://github.com/pull/42',
     number: 42
@@ -47,8 +59,8 @@ beforeEach(() => {
 describe('run', () => {
   describe('when there are some errored reviewers', () => {
     beforeEach(() => {
-      jest.spyOn(store, 'getErroredReviewers').mockReturnValue(['username']);
-      jest.spyOn(store, 'getErroredTeamReviewers').mockReturnValue(['team']);
+      jest.mocked(store.getErroredReviewers).mockReturnValue(['username']);
+      jest.mocked(store.getErroredTeamReviewers).mockReturnValue(['team']);
     });
 
     it('reports errored reviewers to a Pull Request comment', async () => {
@@ -66,8 +78,8 @@ describe('run', () => {
 
   describe('when there are no errored reviewers', () => {
     it('does nothing', async () => {
-      jest.spyOn(store, 'getErroredReviewers').mockReturnValue([]);
-      jest.spyOn(store, 'getErroredTeamReviewers').mockReturnValue([]);
+      jest.mocked(store.getErroredReviewers).mockReturnValue([]);
+      jest.mocked(store.getErroredTeamReviewers).mockReturnValue([]);
 
       await postAction.run();
 

--- a/tests/wrapper/find.test.ts
+++ b/tests/wrapper/find.test.ts
@@ -12,26 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as glob from '@actions/glob';
-import * as path from 'path';
+import {jest} from '@jest/globals';
 
-import {findWrapperPropertiesFiles} from '../../src/wrapper/find';
+import * as path from 'path';
+import {fileURLToPath} from 'url';
+
+import {coreMock} from '../mocks/core';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+
+jest.unstable_mockModule('@actions/glob', () => ({
+  create: jest.fn()
+}));
+
+const glob = await import('@actions/glob');
+const {findWrapperPropertiesFiles} = await import('../../src/wrapper/find');
 
 describe('findWrapperPropertiesFiles', () => {
   it('filters paths based on include and ignore lists', async () => {
-    const pathPrefix = path.dirname(__filename);
+    const pathPrefix = path.dirname(fileURLToPath(import.meta.url));
 
-    jest.spyOn(glob, 'create').mockResolvedValue({
+    jest.mocked(glob.create).mockResolvedValue({
       getSearchPaths: jest.fn(),
       glob: jest
-        .fn()
-        .mockReturnValue([
+        .fn<() => Promise<string[]>>()
+        .mockResolvedValue([
           `${pathPrefix}/path_a/gradle/wrapper/gradle-wrapper.properties`,
           `${pathPrefix}/path_b/gradle/wrapper/gradle-wrapper.properties`,
           `${pathPrefix}/path_b/subpath_c/gradle/wrapper/gradle-wrapper.properties`
         ]),
       globGenerator: jest.fn()
-    });
+    } as unknown as Awaited<ReturnType<typeof glob.create>>);
 
     const tests: {
       pathsInclude: string[];

--- a/tests/wrapperInfo.test.ts
+++ b/tests/wrapperInfo.test.ts
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {jest} from '@jest/globals';
+
 import * as path from 'path';
 
-import {createWrapperInfo} from '../src/wrapperInfo';
+import {coreMock} from './mocks/core';
+
+jest.unstable_mockModule('@actions/core', coreMock);
+
+const {createWrapperInfo} = await import('../src/wrapperInfo');
 
 test('parses a valid properties file', () => {
   const propsPath = path.resolve('tests/data/gradle-wrapper.properties');


### PR DESCRIPTION
Refactor tests to use Jest's ESM support and unstable mocking APIs, removes legacy mocks, and introduces custom mock modules for dependencies.